### PR TITLE
逻辑运算（4/8）添加ORI指令

### DIFF
--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -1,26 +1,48 @@
+`include "../utils/defines2.vh"
 `timescale 1ns / 1ps
 
 module aludec(
-    input [1:0] aluop,
+    input [5:0] op,
     input [5:0] funct,
     output reg [2:0] aluctrl
     );
 
-    // 照表填
-    always@(*)begin
-        case(aluop)
-            2'b00:aluctrl = 3'b010;               //lw、sw
-            2'b01:aluctrl = 3'b110;               //beq
-            2'b10:begin                          
-                case(funct)
-                    6'b10_0000:aluctrl = 3'b010;  //add
-                    6'b10_0010:aluctrl = 3'b110;  //sub
-                    6'b10_0100:aluctrl = 3'b000;  //and
-                    6'b10_0101:aluctrl = 3'b001;  //or
-                    6'b10_1010:aluctrl = 3'b111;  //slt
-                endcase
-            end
-            default:aluctrl = 3'd0;
+// 3'b000 -> (num1&num2): // AND
+// 3'b001 -> (num1|num2): // OR
+// 3'b010 -> (num1+num2): // ADD
+// 3'b110 -> (num1-num2): // SUB
+// 3'b111 -> (num1<num2): // SLT
+
+    always @(*) begin
+        case(op)
+            `R_TYPE: case(funct)
+                `ADD: aluctrl = 3'b010;
+                `SUB: aluctrl = 3'b110;
+                `AND: aluctrl = 3'b000;
+                `OR:  aluctrl = 3'b001;
+                `SLT: aluctrl = 3'b111;
+            endcase
+            `LW, `SW, `ADDI, `J: aluctrl = 3'b010;
+            `BEQ: aluctrl = 3'b010;
+            default: aluctrl = 3'b000;
         endcase
     end
+
+    // // 照表填
+    // always@(*)begin
+    //     case(aluop)
+    //         2'b00:aluctrl = 3'b010;               //lw、sw, the aluctrl refers to ADD ALU
+    //         2'b01:aluctrl = 3'b110;               //beq, the aluctrl refers to SUB ALU
+    //         2'b10:begin // different situations
+    //             case(funct)
+    //                 6'b10_0000:aluctrl = 3'b010;  //add
+    //                 6'b10_0010:aluctrl = 3'b110;  //sub
+    //                 6'b10_0100:aluctrl = 3'b000;  //and
+    //                 6'b10_0101:aluctrl = 3'b001;  //or
+    //                 6'b10_1010:aluctrl = 3'b111;  //slt
+    //             endcase
+    //         end
+    //         default:aluctrl = 3'd0;
+    //     endcase
+    // end
 endmodule

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -4,7 +4,7 @@
 module aludec(
     input [5:0] op,
     input [5:0] funct,
-    output reg [2:0] aluctrl
+    output reg [4:0] aluctrl
     );
 
 // 3'b000 -> (num1&num2): // AND
@@ -16,11 +16,11 @@ module aludec(
     always @(*) begin
         case(op)
             `R_TYPE: case(funct)
-                `ADD: aluctrl = 3'b010;
-                `SUB: aluctrl = 3'b110;
-                `AND: aluctrl = 3'b000;
-                `OR:  aluctrl = 3'b001;
-                `SLT: aluctrl = 3'b111;
+                `ADD: aluctrl = `ADD_CONTROL;
+                `SUB: aluctrl = `SUB_CONTROL;
+                `AND: aluctrl = `AND_CONTROL;
+                `OR:  aluctrl = `OR_CONTROL;
+                `SLT: aluctrl = `SLT_CONTROL;
             endcase
             `LW, `SW, `ADDI, `J: aluctrl = 3'b010;
             `BEQ: aluctrl = 3'b010;

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -24,6 +24,7 @@ module aludec(
             endcase
             `LW, `SW, `ADDI, `J: aluctrl = 3'b010;
             `BEQ: aluctrl = 3'b010;
+            `LUI: aluctrl = 3'b001;
             default: aluctrl = 3'b000;
         endcase
     end

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -19,6 +19,7 @@ module aludec(
             `LW, `SW, `ADDI, `J: aluctrl = `ADD_CONTROL;
             `BEQ: aluctrl = `ADD_CONTROL;
             `LUI: aluctrl = `OR_CONTROL;
+            `ORI: aluctrl = `OR_CONTROL;
             default: aluctrl = `AND_CONTROL;
         endcase
     end

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -7,12 +7,6 @@ module aludec(
     output reg [4:0] aluctrl
     );
 
-// 3'b000 -> (num1&num2): // AND
-// 3'b001 -> (num1|num2): // OR
-// 3'b010 -> (num1+num2): // ADD
-// 3'b110 -> (num1-num2): // SUB
-// 3'b111 -> (num1<num2): // SLT
-
     always @(*) begin
         case(op)
             `R_TYPE: case(funct)
@@ -22,10 +16,10 @@ module aludec(
                 `OR:  aluctrl = `OR_CONTROL;
                 `SLT: aluctrl = `SLT_CONTROL;
             endcase
-            `LW, `SW, `ADDI, `J: aluctrl = 3'b010;
-            `BEQ: aluctrl = 3'b010;
-            `LUI: aluctrl = 3'b001;
-            default: aluctrl = 3'b000;
+            `LW, `SW, `ADDI, `J: aluctrl = `ADD_CONTROL;
+            `BEQ: aluctrl = `ADD_CONTROL;
+            `LUI: aluctrl = `OR_CONTROL;
+            default: aluctrl = `AND_CONTROL;
         endcase
     end
 

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -12,7 +12,7 @@ module controller(
 	input flushE,
 	output memtoregE,alusrcE,
 	output regdstE,regwriteE,
-	output [2:0] alucontrolE,
+	output [4:0] alucontrolE,
 
 	//mem stage
 	output memtoregM,memwriteM,regwriteM,
@@ -24,7 +24,7 @@ module controller(
 
 	//decode stage
 	wire memtoregD,memwriteD,alusrcD,regdstD,regwriteD;
-	wire[2:0] alucontrolD;
+	wire[4:0] alucontrolD;
 	//execute stage
 	wire memwriteE;
 
@@ -33,7 +33,7 @@ module controller(
 	// [decode -> execute]
 	assign pcsrcD = branchD & equalD;
 	// 注意，这里存在flush可能性
-	floprc #(8) regE(
+	floprc #(10) regE(
 		clk, rst,
 		flushE,
 		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD},

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -3,27 +3,26 @@
 
 module controller(
 	input clk,rst,
-	
+
 	//decode stage
 	input [5:0] opD,functD,equalD,
 	output pcsrcD,branchD,jumpD,
-	
+
 	//execute stage
 	input flushE,
 	output memtoregE,alusrcE,
-	output regdstE,regwriteE,	
+	output regdstE,regwriteE,
 	output [2:0] alucontrolE,
 
 	//mem stage
 	output memtoregM,memwriteM,regwriteM,
-	
+
 	//write back stage
 	output memtoregW,regwriteW
 
 );
 
 	//decode stage
-	wire[1:0] aluopD;
 	wire memtoregD,memwriteD,alusrcD,regdstD,regwriteD;
 	wire[2:0] alucontrolD;
 	//execute stage
@@ -69,13 +68,12 @@ module controller(
         .branch(branchD),
         .memWrite(memwriteD),
         .memToReg(memtoregD),
-        .jump(jumpD),
-        .aluop(aluopD)
+        .jump(jumpD)
         //output
 	);
 
 	aludec control_aludec(
-		.aluop(aluopD),
+		.op(opD),
         .funct(functD),
         //input
         .aluctrl(alucontrolD)

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -1,48 +1,98 @@
+`include "../utils/defines2.vh"
 `timescale 1ns / 1ps
 
 module maindec(
     input [5:0] op,
-    output reg regwrite,    
-    output reg regdst,      
-    output reg alusrc,      
-    output reg branch,      
-    output reg memWrite,    
-    output reg memToReg,    
-    output reg jump,        
-    //pcsrc被忽略掉了
-    output reg [1:0] aluop
+    output reg regwrite,
+    output reg regdst,
+    output reg alusrc,
+    output reg branch,
+    output reg memWrite,
+    output reg memToReg,
+    output reg jump
     );
-    //顺序按表5
-    always@(*)begin
+
+    // regwrite
+    always @(*) begin
         case(op)
-            6'b000000:begin     //R-type
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1100000;  
-                aluop=2'b10;
-            end
-            6'b100011:begin     //lw
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1010010;
-                aluop=2'b00;
-            end
-            6'b101011:begin     //sw
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0010100;
-                aluop=2'b00;
-            end
-            6'b000100:begin     //beq
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0001000;
-                aluop=2'b01;
-            end
-            6'b001000:begin     //I-type
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1010000;
-                aluop=2'b00;
-            end
-            6'b000010:begin     //jump
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0000001;
-                aluop=2'b00;
-            end
-            default:begin
-                {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'd0;
-                aluop=2'b00;
-            end
+            `R_TYPE, `LW, `ADDI, `ANDI: regwrite = 1'b1;
+            default: regwrite = 1'b0;
         endcase
     end
+    // regdst
+    always @(*) begin
+        case(op)
+            `R_TYPE: regdst = 1'b1;
+            default: regdst = 1'b0;
+        endcase
+    end
+    // alusrc
+    always @(*) begin
+        case(op)
+            `SW, `LW, `ADDI, `ANDI: alusrc = 1'b1;
+            default: alusrc = 1'b0;
+        endcase
+    end
+    // branch
+    always @(*) begin
+        case(op)
+            `BEQ: branch = 1'b1;
+            default: branch = 1'b0;
+        endcase
+    end
+    // memWrite
+    always @(*) begin
+        case(op)
+            `SW: memWrite = 1'b1;
+            default: memWrite = 1'b0;
+        endcase
+    end
+    // memToReg
+    always @(*) begin
+        case(op)
+            `LW: memToReg = 1'b1;
+            default: memToReg = 1'b0;
+        endcase
+    end
+    // jump
+    always @(*) begin
+        case(op)
+            `J: jump = 1'b1;
+            default: jump = 1'b0;
+        endcase
+    end
+
+    // //顺序按表5
+    // always@(*)begin
+    //     case(op)
+    //         6'b000000:begin     //R-type
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1100000;
+    //             aluop=2'b10;
+    //         end
+    //         6'b100011:begin     //lw
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1010010;
+    //             aluop=2'b00;
+    //         end
+    //         6'b101011:begin     //sw
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0010100;
+    //             aluop=2'b00;
+    //         end
+    //         6'b000100:begin     //beq
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0001000;
+    //             aluop=2'b01;
+    //         end
+    //         6'b001000:begin     //I-type
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b1010000;
+    //             aluop=2'b00;
+    //         end
+    //         6'b000010:begin     //jump
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'b0000001;
+    //             aluop=2'b00;
+    //         end
+    //         default:begin
+    //             {regwrite,regdst,alusrc,branch,memWrite,memToReg,jump}=7'd0;
+    //             aluop=2'b00;
+    //         end
+    //     endcase
+    // end
 endmodule

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -15,7 +15,7 @@ module maindec(
     // regwrite
     always @(*) begin
         case(op)
-            `R_TYPE, `LW, `ADDI, `ANDI: regwrite = 1'b1;
+            `R_TYPE, `LW, `ADDI, `ANDI, `LUI: regwrite = 1'b1;
             default: regwrite = 1'b0;
         endcase
     end
@@ -29,7 +29,7 @@ module maindec(
     // alusrc
     always @(*) begin
         case(op)
-            `SW, `LW, `ADDI, `ANDI: alusrc = 1'b1;
+            `SW, `LW, `ADDI, `ANDI, `LUI: alusrc = 1'b1;
             default: alusrc = 1'b0;
         endcase
     end

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -15,7 +15,8 @@ module maindec(
     // regwrite
     always @(*) begin
         case(op)
-            `R_TYPE, `LW, `ADDI, `ANDI, `LUI: regwrite = 1'b1;
+            `R_TYPE, `LW,
+            `ADDI, `ANDI, `LUI, `ORI: regwrite = 1'b1;
             default: regwrite = 1'b0;
         endcase
     end
@@ -29,7 +30,8 @@ module maindec(
     // alusrc
     always @(*) begin
         case(op)
-            `SW, `LW, `ADDI, `ANDI, `LUI: alusrc = 1'b1;
+            `SW, `LW,
+            `ADDI, `ANDI, `LUI, `ORI: alusrc = 1'b1;
             default: alusrc = 1'b0;
         endcase
     end

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -14,7 +14,7 @@ module datapath(
 	input memtoregE,
 	input alusrcE,regdstE,
 	input regwriteE,
-	input [2:0] alucontrolE,
+	input [4:0] alucontrolE,
 	output flushE,
 	//mem stage
 	input memtoregM,

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -25,7 +25,7 @@ module datapath(
 	input memtoregW,
 	input regwriteW
 );
-	
+
 	//fetch stage
 	wire stallF;
 	wire [31:0] pc_plus4F;
@@ -35,7 +35,7 @@ module datapath(
 	wire [31:0] pc_plus4D,instrD;
 	wire forwardaD,forwardbD;
 	wire [4:0] rsD,rtD,rdD;
-	wire stallD; 
+	wire stallD;
 	wire [31:0] signimmD,signimm_slD;
 	wire [31:0] srcaD,srca2D,srcbD,srcb2D;
 
@@ -62,7 +62,7 @@ module datapath(
 
 	// 有可能暂停的flip要带en
 	// 有可能flush的flip要带clear
-	
+
 	// [fetch -> decode]
 	// 暂存
 	flopenr r1D(clk,rst,~stallD,pc_plus4F,pc_plus4D);
@@ -114,7 +114,7 @@ module datapath(
 		//decode stage
 		.rsD(rsD),
 		.rtD(rtD),
-		.branchD(branchD), 
+		.branchD(branchD),
 		.forwardaD(forwardaD),
 		.forwardbD(forwardbD),
 		.stallD(stallD),
@@ -155,8 +155,8 @@ module datapath(
 	// [Fetch] PC + 4
 	adder adder_plus4(pcF,32'd4,pc_plus4F);
 
-	// [Decode] 符号扩展
-	signext SignExtend(instrD[15:0],signimmD);
+	// [Decode] 数据扩展
+	signext DataExtend(opD, instrD[15:0], signimmD);
 	// [Decode] 左移两位
 	sl2 immsh(signimmD,signimm_slD);
 	// [Decode] 计算branch的地址
@@ -181,7 +181,7 @@ module datapath(
 	// [Execute] 决定 write register 是 rt 还是 rd
 	mux2 #(5) mux_regdst(rtE,rdE,regdstE,writeregE);
     // [Execute] 针对寄存器堆，进行操作
-	regfile register(clk,regwriteW,rsD,rtD,writeregW,resultW,srcaD,srcbD);
+	regfile register(clk,rst,regwriteW,rsD,rtD,writeregW,resultW,srcaD,srcbD);
     // [Execute] 判断ALU收到的srcB是RD2还是SignImm
 	mux2 mux_ALUsrc(srcb2E,signimmE,alusrcE,srcb3E);
     // [Execute] ALU运算，控制冒险提前判断了branch，不再需要zero

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -8,11 +8,11 @@ module mips(
 	output memwriteM,
 	output [31:0] aluoutM,writedataM
 );
-	
+
 	wire [5:0] opD,functD;
 	wire regdstE,alusrcE,pcsrcD,memtoregE,memtoregM,memtoregW;
 	wire regwriteE,regwriteM,regwriteW;
-	wire [2:0] alucontrolE;
+	wire [4:0] alucontrolE;
 	wire flushE,equalD;
 
 	controller c(
@@ -31,7 +31,7 @@ module mips(
 		//				==input==
 		.flushE(flushE),
 			//output
-		.memtoregE(memtoregE), 		.alusrcE(alusrcE), 		
+		.memtoregE(memtoregE), 		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
 		.alucontrolE(alucontrolE),
 		//[mem stage]
@@ -77,5 +77,5 @@ module mips(
 		.memtoregW(memtoregW), 		.regwriteW(regwriteW)
 		//				==output=
 	);
-	
+
 endmodule

--- a/inst52/myCPU/utils/alu.v
+++ b/inst52/myCPU/utils/alu.v
@@ -6,10 +6,10 @@ module alu(
     input [2:0]op,
     output [31:0]result
     );
-assign result = (op==3'b000)?(num1&num2):
-                (op==3'b001)?(num1|num2):
-                (op==3'b010)?(num1+num2):
-                (op==3'b110)?(num1-num2):
-                (op==3'b111)?(num1<num2):
+assign result = (op==3'b000)?(num1&num2): // AND
+                (op==3'b001)?(num1|num2): // OR
+                (op==3'b010)?(num1+num2): // ADD
+                (op==3'b110)?(num1-num2): // SUB
+                (op==3'b111)?(num1<num2): // SLT
                 32'hxxxx_xxxx;
 endmodule

--- a/inst52/myCPU/utils/alu.v
+++ b/inst52/myCPU/utils/alu.v
@@ -1,15 +1,16 @@
+`include "./defines2.vh"
 `timescale 1ns / 1ps
 
 module alu(
     input [31:0]num1,
     input [31:0]num2,
-    input [2:0]op,
+    input [4:0]op,
     output [31:0]result
     );
-assign result = (op==3'b000)?(num1&num2): // AND
-                (op==3'b001)?(num1|num2): // OR
-                (op==3'b010)?(num1+num2): // ADD
-                (op==3'b110)?(num1-num2): // SUB
-                (op==3'b111)?(num1<num2): // SLT
+assign result = (op==`AND_CONTROL)?(num1&num2): // AND
+                (op==`OR_CONTROL)?(num1|num2): // OR
+                (op==`ADD_CONTROL)?(num1+num2): // ADD
+                (op==`SUB_CONTROL)?(num1-num2): // SUB
+                (op==`SLT_CONTROL)?(num1<num2): // SLT
                 32'hxxxx_xxxx;
 endmodule

--- a/inst52/myCPU/utils/regfile.v
+++ b/inst52/myCPU/utils/regfile.v
@@ -1,27 +1,28 @@
 `timescale 1ns / 1ps
 //////////////////////////////////////////////////////////////////////////////////
-// Company: 
-// Engineer: 
-// 
+// Company:
+// Engineer:
+//
 // Create Date: 2017/11/02 14:20:09
-// Design Name: 
+// Design Name:
 // Module Name: regfile
-// Project Name: 
-// Target Devices: 
-// Tool Versions: 
-// Description: 
-// 
-// Dependencies: 
-// 
+// Project Name:
+// Target Devices:
+// Tool Versions:
+// Description:
+//
+// Dependencies:
+//
 // Revision:
 // Revision 0.01 - File Created
 // Additional Comments:
-// 
+//
 //////////////////////////////////////////////////////////////////////////////////
 
 
 module regfile(
 	input wire clk,
+	input wire rst,
 	input wire we3,
 	input wire[4:0] ra1,ra2,wa3,
 	input wire[31:0] wd3,
@@ -31,8 +32,13 @@ module regfile(
 	reg [31:0] rf[31:0];
 
 	always @(negedge clk) begin
-		if(we3) begin
-			 rf[wa3] <= wd3;
+		if (rst) begin
+			rf[wa3] <= 0;
+		end
+		else begin
+			if(we3) begin
+				rf[wa3] <= wd3;
+			end
 		end
 	end
 

--- a/inst52/myCPU/utils/regfile.v
+++ b/inst52/myCPU/utils/regfile.v
@@ -31,14 +31,16 @@ module regfile(
 
 	reg [31:0] rf[31:0];
 
-	always @(negedge clk) begin
-		if (rst) begin
-			rf[wa3] <= 0;
+	integer i;
+	initial begin
+		for (i = 0; i < 32; i = i + 1) begin
+			rf[i] = 32'd00000000;
 		end
-		else begin
-			if(we3) begin
-				rf[wa3] <= wd3;
-			end
+	end
+
+	always @(negedge clk) begin
+		if(we3) begin
+			rf[wa3] <= wd3;
 		end
 	end
 

--- a/inst52/myCPU/utils/signext.v
+++ b/inst52/myCPU/utils/signext.v
@@ -6,7 +6,7 @@ module signext(
     input [15:0] a,
     output reg [31:0] a_ext
     );
-    // 符号扩展
+    // 数据扩展
     always @(*) begin
         case(op)
             `LUI: a_ext = {a, {16{1'b0}}};

--- a/inst52/myCPU/utils/signext.v
+++ b/inst52/myCPU/utils/signext.v
@@ -1,9 +1,16 @@
+`include "./defines2.vh"
 `timescale 1ns / 1ps
 
 module signext(
+    input [5:0] op,
     input [15:0] a,
-    output [31:0] a_ext
+    output reg [31:0] a_ext
     );
     // 符号扩展
-    assign a_ext={ {16{a[15]}} ,a}; 
+    always @(*) begin
+        case(op)
+            `LUI: a_ext = {a, {16{1'b0}}};
+            default: a_ext = { {16{a[15]}} ,a};
+        endcase
+    end
 endmodule

--- a/inst52/myCPU/utils/signext.v
+++ b/inst52/myCPU/utils/signext.v
@@ -10,6 +10,7 @@ module signext(
     always @(*) begin
         case(op)
             `LUI: a_ext = {a, {16{1'b0}}};
+            `ORI: a_ext = {{16{1'b0}}, a};
             default: a_ext = { {16{a[15]}} ,a};
         endcase
     end


### PR DESCRIPTION
- 将alucontrol的位数扩充至5位，为以后的更多操作预留空间
- 将alucontrol的写法换成宏，增加可读性
- 在dataExtend模块添加无符号扩展
- 添加ORI指令

实现细节：
- 对于ORI指令，拿到的立即数通过无符号扩展变成32位
- 在ALU与rs取出的值进行或运算
- 写回rt

到目前为止，`LogicTest`中的前四条指令都可以在寄存器中正常存储，分别是：
```
_start:
   lui  $1,0x0101			## $1 = 0x01010000
   ori  $1,$1,0x0101		## S1 = 0x01010101
   ori  $2,$1,0x1100        ## $2 = $1 | 0x1100 = 0x01011101
   or   $1,$1,$2            ## $1 = $1 | $2 = 0x01011101
```