### PR TITLE
分支跳转（12/12）但BAL有问题

### DIFF
--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -33,8 +33,8 @@ module aludec(
                 `SRAV: aluctrl = `SRAV_CONTROL;
             endcase
             `LW, `SW: aluctrl = `ADD_CONTROL;
-            `J: aluctrl = `ADD_CONTROL;
-            `INST_SET_BRANCH: aluctrl = `ADD_CONTROL;
+            `J, `JAL: aluctrl = `ADD_CONTROL; // TODO: 我假设这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
+            `INST_SET_BRANCH: aluctrl = `ADD_CONTROL; // TODO: 我假设这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
             `LUI: aluctrl = `OR_CONTROL;
             `ORI: aluctrl = `OR_CONTROL;
             `XORI: aluctrl = `XOR_CONTROL;

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -31,6 +31,8 @@ module aludec(
                 `SLLV: aluctrl = `SLLV_CONTROL;
                 `SRLV: aluctrl = `SRLV_CONTROL;
                 `SRAV: aluctrl = `SRAV_CONTROL;
+                // ...
+                default: aluctrl = `ADD_CONTROL;
             endcase
             `LW, `SW: aluctrl = `ADD_CONTROL;
             `J, `JAL: aluctrl = `ADD_CONTROL; // TODO: 我假设这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看

--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -1,5 +1,7 @@
 `include "../utils/defines2.vh"
 `timescale 1ns / 1ps
+`define INST_SET_BRANCH `BEQ, `BNE, `BGTZ, `BLEZ, `BG_EXT_INST
+`define USELESS_CONTROL `AND_CONTROL
 
 module aludec(
     input [5:0] op,
@@ -30,8 +32,9 @@ module aludec(
                 `SRLV: aluctrl = `SRLV_CONTROL;
                 `SRAV: aluctrl = `SRAV_CONTROL;
             endcase
-            `LW, `SW, `J: aluctrl = `ADD_CONTROL;
-            `BEQ: aluctrl = `ADD_CONTROL;
+            `LW, `SW: aluctrl = `ADD_CONTROL;
+            `J: aluctrl = `ADD_CONTROL;
+            `INST_SET_BRANCH: aluctrl = `ADD_CONTROL;
             `LUI: aluctrl = `OR_CONTROL;
             `ORI: aluctrl = `OR_CONTROL;
             `XORI: aluctrl = `XOR_CONTROL;

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -5,12 +5,13 @@ module controller(
 	input clk,rst,
 
 	//decode stage
-	input [5:0] opD,functD,equalD,
+	input [5:0] opD,rsD,rtD,functD,validBranchConditionD,
 	output pcsrcD,branchD,jumpD,
 
 	//execute stage
 	input flushE,
 	output memtoregE,alusrcE,
+	output balE,
 	output regdstE,regwriteE,
 	output [4:0] alucontrolE,
 
@@ -25,6 +26,7 @@ module controller(
 
 	//decode stage
 	wire memtoregD,memwriteD,alusrcD,regdstD,regwriteD;
+	wire balD;
 	wire[4:0] alucontrolD;
 	//execute stage
 	wire memwriteE;
@@ -32,13 +34,13 @@ module controller(
 	// 用不到的，就继续传
 
 	// [decode -> execute]
-	assign pcsrcD = branchD & equalD;
+	assign pcsrcD = branchD & validBranchConditionD;
 	// 注意，这里存在flush可能性
-	floprc #(10) regE(
+	floprc #(11) regE(
 		clk, rst,
 		flushE,
-		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD},
-		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE}
+		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD,balD},
+		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE,balE}
 	);
 
 	// [execute -> mem]
@@ -62,11 +64,14 @@ module controller(
 
 	maindec control_maindec(
 		.op(opD),
+		.rs(rsD),
+		.rt(rtD),
 		//input
         .regwrite(regwriteD),
         .regdst(regdstD),
         .alusrc(alusrcD),
         .branch(branchD),
+		.bal(balD),
         .memWrite(memwriteD),
         .memToReg(memtoregD),
         .jump(jumpD)

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -5,13 +5,14 @@ module controller(
 	input clk,rst,
 
 	//decode stage
-	input [5:0] opD,rsD,rtD,functD,validBranchConditionD,
-	output pcsrcD,branchD,jumpD,jalD,
+	input [4:0] rsD,rtD,
+	input [5:0] opD,functD,validBranchConditionD,
+	output pcsrcD,branchD,jumpD,jalD,jrD,
 
 	//execute stage
 	input flushE,
 	output memtoregE,alusrcE,
-	output balE,jalE,
+	output balE,jalE,jrE,
 	output regdstE,regwriteE,
 	output [4:0] alucontrolE,
 
@@ -36,11 +37,11 @@ module controller(
 	// [decode -> execute]
 	assign pcsrcD = branchD & validBranchConditionD;
 	// 注意，这里存在flush可能性
-	floprc #(12) regE(
+	floprc #(13) regE(
 		clk, rst,
 		flushE,
-		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD,balD,jalD},
-		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE,balE,jalE}
+		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD,balD,jalD,jrD},
+		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE,balE,jalE,jrE}
 	);
 
 	// [execute -> mem]
@@ -66,6 +67,8 @@ module controller(
 		.op(opD),
 		.rs(rsD),
 		.rt(rtD),
+		.rd(rdD),
+		.funct(functD),
 		//input
         .regwrite(regwriteD),
         .regdst(regdstD),
@@ -73,6 +76,7 @@ module controller(
         .branch(branchD),
 		.bal(balD),
 		.jal(jalD),
+		.jr(jrD),
         .memWrite(memwriteD),
         .memToReg(memtoregD),
         .jump(jumpD)

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -6,12 +6,12 @@ module controller(
 
 	//decode stage
 	input [5:0] opD,rsD,rtD,functD,validBranchConditionD,
-	output pcsrcD,branchD,jumpD,
+	output pcsrcD,branchD,jumpD,jalD,
 
 	//execute stage
 	input flushE,
 	output memtoregE,alusrcE,
-	output balE,
+	output balE,jalE,
 	output regdstE,regwriteE,
 	output [4:0] alucontrolE,
 
@@ -36,11 +36,11 @@ module controller(
 	// [decode -> execute]
 	assign pcsrcD = branchD & validBranchConditionD;
 	// 注意，这里存在flush可能性
-	floprc #(11) regE(
+	floprc #(12) regE(
 		clk, rst,
 		flushE,
-		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD,balD},
-		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE,balE}
+		{memtoregD,memwriteD,alusrcD,regdstD,regwriteD,alucontrolD,balD,jalD},
+		{memtoregE,memwriteE,alusrcE,regdstE,regwriteE,alucontrolE,balE,jalE}
 	);
 
 	// [execute -> mem]
@@ -72,6 +72,7 @@ module controller(
         .alusrc(alusrcD),
         .branch(branchD),
 		.bal(balD),
+		.jal(jalD),
         .memWrite(memwriteD),
         .memToReg(memtoregD),
         .jump(jumpD)

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -24,10 +24,7 @@ module maindec(
             `R_TYPE, `LW,
             `INST_SET_IMMEDIATE: regwrite = `regwrite_ON;
             `INST_SET_BRANCH: begin
-                case(rt)
-                    `BGEZAL, `BLTZAL: regwrite = `regwrite_ON;
-                    default: regwrite = `regwrite_OFF;
-                endcase
+                regwrite = (rt == `BGEZAL || rt == `BLTZAL) ? `regwrite_ON : `regwrite_OFF;
             end
             default: regwrite = `regwrite_OFF;
         endcase

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -13,6 +13,7 @@ module maindec(
     output reg alusrc,
     output reg branch,
     output reg bal,
+    output reg jal,
     output reg memWrite,
     output reg memToReg,
     output reg jump
@@ -26,6 +27,7 @@ module maindec(
             `INST_SET_BRANCH: begin
                 regwrite = (rt == `BGEZAL || rt == `BLTZAL) ? `regwrite_ON : `regwrite_OFF;
             end
+            `JAL: regwrite = `regwrite_ON;
             default: regwrite = `regwrite_OFF;
         endcase
     end
@@ -74,8 +76,18 @@ module maindec(
     // jump
     always @(*) begin
         case(op)
-            `J: jump = `jump_ON;
-            default: jump = `jump_OFF;
+            `J: begin
+                jump = `jump_ON;
+                jal = `jal_OFF;
+            end
+            `JAL: begin
+                jump = `jump_ON;
+                jal = `jal_ON;
+            end
+            default: begin
+                jump = `jump_OFF;
+                jal = `jal_OFF;
+            end
         endcase
     end
 

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -8,15 +8,16 @@ module datapath(
 	output [31:0] pcF,
 	//decode stage
 	input pcsrcD,branchD,
-	input jumpD,jalD,
+	input jumpD,jalD,jrD,
 	output reg validBranchConditionD,
-	output [5:0] opD,rsD,rtD,functD,
+	output [4:0] rsD,rtD,
+	output [5:0] opD,functD,
 	//execute stage
 	input memtoregE,
 	input alusrcE,regdstE,
 	input regwriteE,
 	input [4:0] alucontrolE,
-	input balE, jalE,
+	input balE, jalE, jrE,
 	output flushE,
 	//mem stage
 	input memtoregM,
@@ -36,10 +37,11 @@ module datapath(
 	wire [31:0] pc_afterjumpD,pc_afterbranchD,pc_branch_offsetD;
 	wire [31:0] pc_plus4D, pc_plus8D, instrD;
 	wire forwardaD,forwardbD;
+	wire jrstall_READ;
 	wire [4:0] rdD;
 	wire stallD;
 	wire [31:0] signimmD,signimm_slD;
-	wire [31:0] srcaD,srca2D,srcbD,srcb2D;
+	wire [31:0] srcaD,srca2D,srcbD,srcb2D,srca3D,srcb3D;
     wire [4:0] saD;
 
 	//execute stage
@@ -75,6 +77,9 @@ module datapath(
 	// 前推
 	mux2 forwardamux(srcaD,aluoutM,forwardaD,srca2D);
 	mux2 forwardbmux(srcbD,aluoutM,forwardbD,srcb2D);
+	mux2 forwardJR(srca2D,readdataM,jrstall_READ, srca3D);
+	assign srcb3D = srcb2D;
+	// 其实只有srca有可能是jr前推的结果，才会有srca3D，但为了整齐将srcb3D也写上了
 
 	// [decode]
 	assign opD = instrD[31:26];
@@ -88,21 +93,20 @@ module datapath(
 
 	always @(*) begin
 		case(opD)
-			`BEQ: validBranchConditionD = (srca2D == srcb2D);
-			`BNE: validBranchConditionD = (srca2D != srcb2D);
-			`BGTZ: validBranchConditionD = (~srca2D[31]) & (srca2D != 32'd0);
-			`BLEZ: validBranchConditionD = (srca2D[31]);
+			`BEQ: validBranchConditionD = (srca3D == srcb3D);
+			`BNE: validBranchConditionD = (srca3D != srcb3D);
+			`BGTZ: validBranchConditionD = (~srca3D[31]) & (srca3D != 32'd0);
+			`BLEZ: validBranchConditionD = (srca3D[31]);
 			`BG_EXT_INST: begin // BG_EXT_INST = 000001, contains: BGEZ,BLTZ,BGEZAL,BLTZAL,
 				case(rtD)
-					`BGEZ: validBranchConditionD = (~srca2D[31]);
-					`BLTZ: validBranchConditionD = (srca2D[31]) | (srca2D == 32'd0);
-					`BGEZAL: validBranchConditionD = (~srca2D[31]);
-					`BLTZAL: validBranchConditionD = (srca2D[31]);
+					`BGEZ: validBranchConditionD = (~srca3D[31]);
+					`BLTZ: validBranchConditionD = (srca3D[31]) | (srca3D == 32'd0);
+					`BGEZAL: validBranchConditionD = (~srca3D[31]);
+					`BLTZAL: validBranchConditionD = (srca3D[31]);
 				endcase
 			end
 		endcase
 	end
-	// assign validBranchConditionD = (srca2D == srcb2D) ? 1'b1:1'b0;
 
 	// [decode -> execute]
 	// 暂存
@@ -141,9 +145,11 @@ module datapath(
 		.rsD(rsD),
 		.rtD(rtD),
 		.branchD(branchD),
+		.jrD(jrD),
 		.forwardaD(forwardaD),
 		.forwardbD(forwardbD),
 		.stallD(stallD),
+		.jrstall_READ(jrstall_READ),
 		//execute stage
 		.rsE(rsE),
 		.rtE(rtE),
@@ -176,8 +182,10 @@ module datapath(
     //            -> 更新PC
     // ====================================
 
+	wire [31:0] pc_next_addr;
+
 	// [Fetch] PC 模块
-	flopenr pcreg(clk,rst,~stallF,pc_afterjumpD,pcF);
+	flopenr pcreg(clk,rst,~stallF,pc_next_addr,pcF);
 	// [Fetch] PC + 4
 	adder adder_plus4(pcF,32'd4,pc_plus4F);
 
@@ -191,7 +199,8 @@ module datapath(
 	//			为了（部分）解决控制冒险，提前判断branch
 	mux2 mux_PCSrc(pc_plus4F,pc_branch_offsetD,pcsrcD,pc_afterbranchD);
 
-	// [Execute] 【特殊情况】如果是BAL或者JAL的操作，pc+8的内容要写入31号寄存器，需要将pc+8传到后面的EXE阶段
+	// [Decode] 【特殊情况】如果是BAL或者JAL的操作，pc+8的内容要写入31号寄存器，需要将pc+8传到后面的EXE阶段
+	//					  如果是JALR的操作，pc+8的内容要写入rd号寄存器
 	adder adder_plus8(pc_plus4D,32'd4,pc_plus8D);
 
 	// [Decode] 判断是否执行jump
@@ -202,18 +211,24 @@ module datapath(
 		pc_afterjumpD
 	);
 
+	// [Decode] 【特殊情况】如果是JR或者JALR，那么无条件跳转的值为寄存器rs中的值
+	wire [31:0] pc_jr = srca2D;
+	// assign pc_next_addr = pc_afterjumpD;
+	mux2 mux_is_jr(pc_afterjumpD,pc_jr,jrD,pc_next_addr);
+
 
     // ====================================
     // Data部分
     // ====================================
 
 
-	wire [4:0] writereg_tempE; // 存储通过regdst得到的寄存器号，但有可能被BAL或JAL覆盖
+	wire [4:0] writereg_tempE; // 存储通过regdst得到的寄存器号，但有可能被BAL、JAL、JALR覆盖
 	wire is_al_instruction;
 	// [Execute] 决定 write register 是 rt 还是 rd
 	mux2 #(5) mux_regdst(rtE,rdE,regdstE,writereg_tempE);
 	// [Execute] 【特殊情况】如果是BAL或者JAL的操作，那么会被强制写回31号寄存器
-	assign is_al_instruction = balE | jalE;
+	//					   但如果是JALR的操作，那么不会覆盖，而是用rd写入
+	assign is_al_instruction = (balE | jalE) & ~(jrE & jalE);
 	mux2 #(5) mux_regdst_al(writereg_tempE, 5'd31, is_al_instruction, writeregE);
 
 
@@ -225,8 +240,9 @@ module datapath(
     // [Execute] ALU运算，控制冒险提前判断了branch，不再需要zero
 	alu alu(srca2E,srcb3E,saE,alucontrolE,aluout_tempE);
 	// [Execute] 【特殊情况】如果是BAL或者JAL的操作，pc+8的内容要写入31号寄存器，需要将pc+8作为aluout的结果
-	mux2 mux_ALUout(aluout_tempE, pc_plus8E, is_al_instruction, aluoutE);
+	//					   如果是JALR的操作，同样要写入pc+8
+	mux2 mux_ALUout(aluout_tempE, pc_plus8E, (balE | jalE), aluoutE);
 
-    // [WriteBack] 判断写回寄存器堆的是：从ALU出来的结果（可能被BAL或JAL覆盖） or 从数据存储器读取的data
+    // [WriteBack] 判断写回寄存器堆的是：从ALU出来的结果（可能被BAL、JAL或JALR覆盖） or 从数据存储器读取的data
 	mux2 mux_regwriteData(aluoutW,readdataW,memtoregW,resultW);
 endmodule

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -1,3 +1,4 @@
+`include "../utils/defines2.vh"
 `timescale 1ns / 1ps
 
 module datapath(
@@ -8,13 +9,14 @@ module datapath(
 	//decode stage
 	input pcsrcD,branchD,
 	input jumpD,
-	output equalD,
-	output [5:0] opD,functD,
+	output reg validBranchConditionD,
+	output [5:0] opD,rsD,rtD,functD,
 	//execute stage
 	input memtoregE,
 	input alusrcE,regdstE,
 	input regwriteE,
 	input [4:0] alucontrolE,
+	input balE,
 	output flushE,
 	//mem stage
 	input memtoregM,
@@ -32,9 +34,9 @@ module datapath(
 
 	//decode stage
 	wire [31:0] pc_afterjumpD,pc_afterbranchD,pc_branch_offsetD;
-	wire [31:0] pc_plus4D,instrD;
+	wire [31:0] pc_plus4D, pc_plus8D, instrD;
 	wire forwardaD,forwardbD;
-	wire [4:0] rsD,rtD,rdD;
+	wire [4:0] rdD;
 	wire stallD;
 	wire [31:0] signimmD,signimm_slD;
 	wire [31:0] srcaD,srca2D,srcbD,srcb2D;
@@ -44,6 +46,7 @@ module datapath(
 	wire [1:0] forwardaE,forwardbE;
 	wire [4:0] rsE,rtE,rdE;
 	wire [4:0] writeregE;
+	wire [31:0] pc_plus4E, pc_plus8E;
 	wire [31:0] signimmE;
 	wire [31:0] srcaE,srca2E,srcbE,srcb2E,srcb3E;
 	wire [31:0] aluoutE;
@@ -81,7 +84,25 @@ module datapath(
 	assign rdD = instrD[15:11];
     assign saD = instrD[10:6];
 	// 提前在decode判断branch
-	assign equalD = (srca2D == srcb2D)?1'b1:1'b0;
+	// 根据指令不同，判断是否valid的格式也不同
+
+	always @(*) begin
+		case(opD)
+			`BEQ: validBranchConditionD = (srca2D == srcb2D);
+			`BNE: validBranchConditionD = (srca2D != srcb2D);
+			`BGTZ: validBranchConditionD = (~srca2D[31]) & (srca2D != 32'd0);
+			`BLEZ: validBranchConditionD = (srca2D[31]);
+			`BG_EXT_INST: begin // BG_EXT_INST = 000001, contains: BGEZ,BLTZ,BGEZAL,BLTZAL,
+				case(rtD)
+					`BGEZ: validBranchConditionD = (~srca2D[31]);
+					`BLTZ: validBranchConditionD = (srca2D[31]) | (srca2D == 32'd0);
+					`BGEZAL: validBranchConditionD = (~srca2D[31]);
+					`BLTZAL: validBranchConditionD = (srca2D[31]);
+				endcase
+			end
+		endcase
+	end
+	// assign validBranchConditionD = (srca2D == srcb2D) ? 1'b1:1'b0;
 
 	// [decode -> execute]
 	// 暂存
@@ -92,6 +113,7 @@ module datapath(
 	floprc #(5) r5E(clk,rst,flushE,rtD,rtE);
 	floprc #(5) r6E(clk,rst,flushE,rdD,rdE);
     floprc #(5) r7E(clk,rst,flushE,saD,saE);
+	floprc #(32) r8E(clk,rst,flushE,pc_plus8D,pc_plus8E);
 	// 前推
 	mux3 forwardaemux(srcaE,resultW,aluoutM,forwardaE,srca2E);
 	mux3 forwardbemux(srcbE,resultW,aluoutM,forwardbE,srcb2E);
@@ -168,6 +190,10 @@ module datapath(
 	// [Decode] 判断是否执行branch
 	//			为了（部分）解决控制冒险，提前判断branch
 	mux2 mux_PCSrc(pc_plus4F,pc_branch_offsetD,pcsrcD,pc_afterbranchD);
+
+	// [EXECUTE] 【特殊情况】如果是BAL或者JAL的操作，pc+8的内容要写入31号寄存器，需要将pc+8传到后面的EXE阶段
+	adder adder_plus8(pc_plus4D,32'd4,pc_plus8D);
+
 	// [Decode] 判断是否执行jump
 	mux2 mux_PCJump(
 		pc_afterbranchD,
@@ -184,13 +210,20 @@ module datapath(
 
 	// [Execute] 决定 write register 是 rt 还是 rd
 	mux2 #(5) mux_regdst(rtE,rdE,regdstE,writeregE);
+	// [Execute] 【特殊情况】如果是BAL或者JAL的操作，那么会被强制写回31号寄存器
+	// TODO: 目前只考虑了BAL情况，还未考虑JAL情况
+	// mux2 mux_regdst_al(writeregE, 5'd31, balE, writeregE);
+
+
     // [Execute] 针对寄存器堆，进行操作
 	regfile register(clk,rst,regwriteW,rsD,rtD,writeregW,resultW,srcaD,srcbD);
     // [Execute] 判断ALU收到的srcB是RD2还是SignImm
 	mux2 mux_ALUsrc(srcb2E,signimmE,alusrcE,srcb3E);
     // [Execute] ALU运算，控制冒险提前判断了branch，不再需要zero
 	alu alu(srca2E,srcb3E,saE,alucontrolE,aluoutE);
+	// [EXECUTE] 【特殊情况】如果是BAL或者JAL的操作，pc+8的内容要写入31号寄存器，需要将pc+8作为aluout的结果
+	// mux2 mux_ALUout(aluoutE, pc_plus8E, balE, aluoutE);
 
-    // [WriteBack] 判断写回寄存器堆的是：ALU的计算结果 or 从数据存储器读取的data
+    // [WriteBack] 判断写回寄存器堆的是：从ALU出来的结果（可能被BAL或JAL覆盖） or 从数据存储器读取的data
 	mux2 mux_regwriteData(aluoutW,readdataW,memtoregW,resultW);
 endmodule

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -10,8 +10,8 @@ module mips(
 );
 
 	wire [5:0] opD,rsD,rtD,functD;
-	wire regdstE,alusrcE,branchD,pcsrcD,memtoregE,memtoregM,memtoregW;
-	wire balE,regwriteE,regwriteM,regwriteW;
+	wire regdstE,alusrcE,branchD,jalD,pcsrcD,memtoregE,memtoregM,memtoregW;
+	wire balE,jalE,regwriteE,regwriteM,regwriteW;
 	wire [4:0] alucontrolE;
 	wire flushE,validBranchConditionD;
 
@@ -35,6 +35,7 @@ module mips(
 		.memtoregE(memtoregE), 		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
 		.alucontrolE(alucontrolE), 	.balE(balE),
+		.jalE(jalE),
 		//[mem stage]
 		//				==input==
 		//				==output=
@@ -56,7 +57,7 @@ module mips(
 		//[decode stage]
 		//				==input==
 		.pcsrcD(pcsrcD),			.branchD(branchD),
-		.jumpD(jumpD),
+		.jumpD(jumpD),				.jalD(jalD),
 		//				==output=
 		.validBranchConditionD(validBranchConditionD), 			.opD(opD),
 		.rsD(rsD),				.rtD(rtD),
@@ -66,6 +67,7 @@ module mips(
 		.memtoregE(memtoregE),		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
 		.alucontrolE(alucontrolE), 	.balE(balE),
+		.jalE(jalE),
 		//				==output=
 		.flushE(flushE),
 		//[mem stage]

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -9,11 +9,11 @@ module mips(
 	output [31:0] aluoutM,writedataM
 );
 
-	wire [5:0] opD,functD;
-	wire regdstE,alusrcE,pcsrcD,memtoregE,memtoregM,memtoregW;
-	wire regwriteE,regwriteM,regwriteW;
+	wire [5:0] opD,rsD,rtD,functD;
+	wire regdstE,alusrcE,branchD,pcsrcD,memtoregE,memtoregM,memtoregW;
+	wire balE,regwriteE,regwriteM,regwriteW;
 	wire [4:0] alucontrolE;
-	wire flushE,equalD;
+	wire flushE,validBranchConditionD;
 
 	controller c(
 		.clk(clk), .rst(rst),
@@ -22,8 +22,9 @@ module mips(
 		//				==output=
 		//[decode stage]
 		//				==input==
-		.opD(opD), 					.functD(functD),
-		.equalD(equalD),
+		.opD(opD), 					.rsD(rsD),
+		.rtD(rtD), 					.functD(functD),
+		.validBranchConditionD(validBranchConditionD),
 		//				==output=
 		.pcsrcD(pcsrcD),			.branchD(branchD),
 		.jumpD(jumpD),
@@ -33,7 +34,7 @@ module mips(
 			//output
 		.memtoregE(memtoregE), 		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
-		.alucontrolE(alucontrolE),
+		.alucontrolE(alucontrolE), 	.balE(balE),
 		//[mem stage]
 		//				==input==
 		//				==output=
@@ -57,13 +58,14 @@ module mips(
 		.pcsrcD(pcsrcD),			.branchD(branchD),
 		.jumpD(jumpD),
 		//				==output=
-		.equalD(equalD), 			.opD(opD),
+		.validBranchConditionD(validBranchConditionD), 			.opD(opD),
+		.rsD(rsD),				.rtD(rtD),
 		.functD(functD),
 		//[execute stage]
 		//				==input==
 		.memtoregE(memtoregE),		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
-		.alucontrolE(alucontrolE),
+		.alucontrolE(alucontrolE), 	.balE(balE),
 		//				==output=
 		.flushE(flushE),
 		//[mem stage]

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -9,9 +9,10 @@ module mips(
 	output [31:0] aluoutM,writedataM
 );
 
-	wire [5:0] opD,rsD,rtD,functD;
-	wire regdstE,alusrcE,branchD,jalD,pcsrcD,memtoregE,memtoregM,memtoregW;
-	wire balE,jalE,regwriteE,regwriteM,regwriteW;
+	wire [5:0] opD,functD;
+	wire [4:0] rsD,rtD;
+	wire regdstE,alusrcE,branchD,jalD,jrD,pcsrcD,memtoregE,memtoregM,memtoregW;
+	wire balE,jalE,jrE,regwriteE,regwriteM,regwriteW;
 	wire [4:0] alucontrolE;
 	wire flushE,validBranchConditionD;
 
@@ -27,7 +28,8 @@ module mips(
 		.validBranchConditionD(validBranchConditionD),
 		//				==output=
 		.pcsrcD(pcsrcD),			.branchD(branchD),
-		.jumpD(jumpD),
+		.jumpD(jumpD),				.jalD(jalD),
+		.jrD(jrD),
 		//[execute stage]
 		//				==input==
 		.flushE(flushE),
@@ -35,7 +37,7 @@ module mips(
 		.memtoregE(memtoregE), 		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
 		.alucontrolE(alucontrolE), 	.balE(balE),
-		.jalE(jalE),
+		.jalE(jalE),				.jrE(jrE),
 		//[mem stage]
 		//				==input==
 		//				==output=
@@ -58,6 +60,7 @@ module mips(
 		//				==input==
 		.pcsrcD(pcsrcD),			.branchD(branchD),
 		.jumpD(jumpD),				.jalD(jalD),
+		.jrD(jrD),					.jrE(jrE),
 		//				==output=
 		.validBranchConditionD(validBranchConditionD), 			.opD(opD),
 		.rsD(rsD),				.rtD(rtD),

--- a/inst52/myCPU/utils/control_signal_define.vh
+++ b/inst52/myCPU/utils/control_signal_define.vh
@@ -21,3 +21,6 @@
 
 `define jump_ON             1'b1
 `define jump_OFF            1'b0
+
+`define jal_ON              1'b1
+`define jal_OFF             1'b0

--- a/inst52/myCPU/utils/control_signal_define.vh
+++ b/inst52/myCPU/utils/control_signal_define.vh
@@ -1,0 +1,23 @@
+`define regwrite_ON 		1'b1
+`define regwrite_OFF        1'b0
+
+`define regdst_RD           1'b1
+`define regdst_RT           1'b0
+
+`define alusrc_IMM          1'b1
+`define alusrc_RD           1'b0
+
+`define branch_ON           1'b1
+`define branch_OFF          1'b0
+
+`define bal_ON              1'b1
+`define bal_OFF             1'b0
+
+`define memWrite_ON         1'b1
+`define memWrite_OFF        1'b0
+
+`define memToReg_MEM        1'b1
+`define memToReg_ALU        1'b0
+
+`define jump_ON             1'b1
+`define jump_OFF            1'b0

--- a/inst52/myCPU/utils/control_signal_define.vh
+++ b/inst52/myCPU/utils/control_signal_define.vh
@@ -1,5 +1,5 @@
-`define regwrite_ON 		1'b1
-`define regwrite_OFF        1'b0
+`define SET_ON 		        1'b1
+`define SET_OFF             1'b0
 
 `define regdst_RD           1'b1
 `define regdst_RT           1'b0
@@ -10,17 +10,5 @@
 `define branch_ON           1'b1
 `define branch_OFF          1'b0
 
-`define bal_ON              1'b1
-`define bal_OFF             1'b0
-
-`define memWrite_ON         1'b1
-`define memWrite_OFF        1'b0
-
 `define memToReg_MEM        1'b1
 `define memToReg_ALU        1'b0
-
-`define jump_ON             1'b1
-`define jump_OFF            1'b0
-
-`define jal_ON              1'b1
-`define jal_OFF             1'b0

--- a/inst52/myCPU/utils/defines2.vh
+++ b/inst52/myCPU/utils/defines2.vh
@@ -48,14 +48,14 @@
 `define SRAV 		6'b000111
 
 `define MFHI  		6'b010000
-`define MTHI  		6'b010001  
+`define MTHI  		6'b010001
 `define MFLO  		6'b010010
 `define MTLO  		6'b010011
 
 `define SLT  6'b101010
 `define SLTU  6'b101011
 `define SLTI  6'b001010
-`define SLTIU  6'b001011   
+`define SLTIU  6'b001011
 `define ADD  6'b100000
 `define ADDU  6'b100001
 `define SUB  6'b100010
@@ -92,12 +92,13 @@
 
 `define SYSCALL 6'b001100
 `define BREAK 6'b001101
-   
+
 `define ERET 5'b10000
 
 `define R_TYPE 6'b000000
 `define REGIMM_INST 6'b000001
 `define SPECIAL3_INST 6'b010000
+`define BG_EXT_INST 6'b000001
 //change the SPECIAL2_INST from 6'b011100 to 6'b010000
 `define MTC0 5'b00100
 `define MFC0 5'b00000
@@ -184,11 +185,11 @@
 `define DivStop 1'b0
 
 //CP0
-`define CP0_REG_BADVADDR    5'b01000       
-`define CP0_REG_COUNT    5'b01001        
-`define CP0_REG_COMPARE    5'b01011      
-`define CP0_REG_STATUS    5'b01100       
-`define CP0_REG_CAUSE    5'b01101       
-`define CP0_REG_EPC    5'b01110          
-`define CP0_REG_PRID    5'b01111         
-`define CP0_REG_CONFIG    5'b10000       
+`define CP0_REG_BADVADDR    5'b01000
+`define CP0_REG_COUNT    5'b01001
+`define CP0_REG_COMPARE    5'b01011
+`define CP0_REG_STATUS    5'b01100
+`define CP0_REG_CAUSE    5'b01101
+`define CP0_REG_EPC    5'b01110
+`define CP0_REG_PRID    5'b01111
+`define CP0_REG_CONFIG    5'b10000


### PR DESCRIPTION
- maindec的写法稍微换了一些
- 扩充branch原本的是否跳转条件（例如BEQ的是否相等），为BNE，BGEZ，BGTZ，BLEZ，BLTZ
- 对于BAL型的，因为会将PC+8写入31号寄存器，因此在设计图中作出如下的改变：
1. 在pc+4D之后，在应用pcsrcD之前，拉一条线存储pc+8D，并且保存至EXE（即，最后为pc+8E）
2. 在通过regdstE决定是rt还是rd写入后，再加一个选择器，判断现在是否为BAL型，如果是那么覆盖原本的寄存器号数为31号
3. 在ALU运算结束的ALUOUT后，再加一个选择器，判断现在是否为BAL型，如果是那么覆盖掉原本的ALUOUT，改为pc+8，这样可以将其写回至31号寄存器

BAL涉及的冒险：
因为在实现中，是将writereg覆盖为31，因此原本的branchstall信号已经可以检测到其冒险

- JAL为无条件跳转，但也如同BAL一样会将PC+8写入31号寄存器。因此作出同样的操作
- JR跳转的地址为寄存器rs的值。这一点可以通过在DECODE阶段，从rs那里拉出一条线来实现。

JR涉及的冒险：
1. JR需要在DECODE时读取rs。但如果上一条指令刚好要写回rs，由于上一条指令只在EXE，还没有得出ALUOUT，因此无法前推。必须让当前JR指令stall一下才行。

- JALR也为无条件跳转，读取rs的值作为地址，但是将PC+8写回rd寄存器。

JALR涉及的冒险：
1. JALR和JR相同，因为读取rs需要stall。
2. JALR还涉及向rd写入，RAW冒险，因此也会有一个stall的需求
