### PR TITLE
访存指令 (8/8)

### DIFF
--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -2,6 +2,7 @@
 `timescale 1ns / 1ps
 `define INST_SET_BRANCH `BEQ, `BNE, `BGTZ, `BLEZ, `BG_EXT_INST
 `define USELESS_CONTROL `AND_CONTROL
+`define INST_SET_LOADSAVE `LW, `LH, `LHU, `LB, `LBU, `SB, `SH, `SW
 
 module aludec(
     input [5:0] op,
@@ -34,9 +35,9 @@ module aludec(
                 // ...
                 default: aluctrl = `ADD_CONTROL;
             endcase
-            `LW, `SW: aluctrl = `ADD_CONTROL;
-            `J, `JAL: aluctrl = `ADD_CONTROL; // TODO: 我假设这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
-            `INST_SET_BRANCH: aluctrl = `ADD_CONTROL; // TODO: 我假设这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
+            `INST_SET_LOADSAVE: aluctrl = `ADD_CONTROL;
+            `J, `JAL: aluctrl = `ADD_CONTROL;         // TODO: 似乎这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
+            `INST_SET_BRANCH: aluctrl = `ADD_CONTROL; // TODO: 似乎这些指令都用不到ALU，之后试着替换成`USELESS_CONTROL看看
             `LUI: aluctrl = `OR_CONTROL;
             `ORI: aluctrl = `OR_CONTROL;
             `XORI: aluctrl = `XOR_CONTROL;

--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -25,7 +25,8 @@ module controller(
 
 
 	//mem stage
-	output memtoregM,memwriteM,regwriteM,hilowriteM,regToHilo_hiM,regToHilo_loM,mdToHiloM,hilotoregM,hilosrcM,
+	output memtoregM,regwriteM,hilowriteM,regToHilo_hiM,regToHilo_loM,mdToHiloM,hilotoregM,hilosrcM,
+	output [3:0] memwriteM,
 
 	//write back stage
 	output memtoregW,regwriteW,hilotoregW
@@ -33,19 +34,21 @@ module controller(
 );
 
 	//decode stage
-	wire memtoregD,memwriteD,alusrcD,regdstD,regwriteD;
+	wire [3:0] memwriteD;
+	wire memtoregD,alusrcD,regdstD,regwriteD;
 	wire regToHilo_hiD,regToHilo_loD,mdToHiloD,mulOrdivD,hilowriteD,hilotoregD,hilosrcD,mdIsSignD;
 	wire balD;
 	wire[4:0] alucontrolD;
 	//execute stage
-	wire memwriteE,hilowriteE;
+	wire [3:0] memwriteE;
+	wire hilowriteE;
 
 	// 用不到的，就继续传
 
 	// [decode -> execute]
 	assign pcsrcD = branchD & validBranchConditionD;
 	// 注意，这里存在flush可能性
-	flopenrc #(21) regE(
+	flopenrc #(24) regE(
 		clk, rst,
         ~stallE,
 		flushE,
@@ -54,7 +57,7 @@ module controller(
 	);
 
 	// [execute -> mem]
-	flopr #(9) regM(
+	flopr #(12) regM(
 		clk,rst,
 		{memtoregE,memwriteE,regwriteE,regToHilo_hiE,regToHilo_loE,mdToHiloE,hilowriteE,hilotoregE,hilosrcE},
 		{memtoregM,memwriteM,regwriteM,regToHilo_hiM,regToHilo_loM,mdToHiloM,hilowriteM,hilotoregM,hilosrcM}

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -18,6 +18,8 @@ module maindec(
     output reg jal,
     output reg jr,
     output reg [3:0] memWrite,
+    output reg [3:0] memReadWidth,
+    output reg memLoadIsSign,
     output reg memToReg,
     output reg jump,
     output reg hilowrite,
@@ -112,6 +114,24 @@ module maindec(
             `SH:            memWrite = `memWrite_HALF;
             `SB:            memWrite = `memWrite_BYTE;
             default:        memWrite = `memWrite_OFF;
+        endcase
+    end
+    // memReadWidth 决定LW/LH/LB时，读取的数据宽度（注意，读取时memWrite仍然为全0。是读取整字之后再根据宽度取出想要的部分）
+    always @(*) begin
+        case(op)
+            `LW:            memReadWidth = `memReadWidth_WORD;
+            `LH:            memReadWidth = `memReadWidth_HALF;
+            `LHU:           memReadWidth = `memReadWidth_HALF;
+            `LB:            memReadWidth = `memReadWidth_BYTE;
+            `LBU:           memReadWidth = `memReadWidth_BYTE;
+            default:        memReadWidth = `memReadWidth_OFF;
+        endcase
+    end
+    // memLoadIsSign - 判断Load指令是否是有符号的（如LHU和LBU）
+    always @(*) begin
+        case(op)
+            `LBU,       `LHU:     memLoadIsSign = `SET_OFF;
+            default:              memLoadIsSign = `SET_ON;
         endcase
     end
     // memToReg

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -17,7 +17,7 @@ module maindec(
     output reg bal,
     output reg jal,
     output reg jr,
-    output reg memWrite,
+    output reg [3:0] memWrite,
     output reg memToReg,
     output reg jump,
     output reg hilowrite,
@@ -93,12 +93,12 @@ module maindec(
     always @(*) begin
         case(op)
             `BEQ,       `BNE,
-            `BGTZ,      `BLEZ:          begin branch = `SET_ON; bal = `SET_OFF; end
+            `BGTZ,      `BLEZ:          begin branch = `SET_ON;  bal = `SET_OFF; end
 
             `BG_EXT_INST: begin
                 case(rt)
-                `BGEZ,      `BLTZ:      begin branch = `SET_ON; bal = `SET_OFF; end
-                `BGEZAL,    `BLTZAL:    begin branch = `SET_ON; bal = `SET_ON; end
+                `BGEZ,      `BLTZ:      begin branch = `SET_ON;  bal = `SET_OFF; end
+                `BGEZAL,    `BLTZAL:    begin branch = `SET_ON;  bal = `SET_ON;  end
                 default:                begin branch = `SET_OFF; bal = `SET_OFF; end
                 endcase
             end
@@ -108,9 +108,10 @@ module maindec(
     // memWrite
     always @(*) begin
         case(op)
-            `SW,        `SB,
-            `SH:            memWrite = `SET_ON;
-            default:        memWrite = `SET_OFF;
+            `SW:            memWrite = `memWrite_WORD;
+            `SH:            memWrite = `memWrite_HALF;
+            `SB:            memWrite = `memWrite_BYTE;
+            default:        memWrite = `memWrite_OFF;
         endcase
     end
     // memToReg

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -5,7 +5,7 @@ module mips(
 	input [31:0] instrF,
 	input [31:0] readdataM,
 	output [31:0] pcF,
-	output memwriteM,
+	output [3:0] memwriteM,
 	output [31:0] aluoutM,writedataM
 );
 

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -5,7 +5,7 @@ module mips(
 	input [31:0] instrF,
 	input [31:0] readdataM,
 	output [31:0] pcF,
-	output [3:0] memwriteM,
+	output [3:0] memwriteEN,
 	output [31:0] aluoutM,writedataM
 );
 
@@ -22,6 +22,9 @@ module mips(
     wire hilotoregM,hilotoregW;
 	wire hilowriteM,hilosrcM;
     wire hilosrcE;
+	wire [3:0] memwriteE;
+	wire [3:0] memReadWidthM;
+	wire memLoadIsSignM;
 
 	controller c(
 		.clk(clk), .rst(rst),
@@ -55,13 +58,14 @@ module mips(
 		//[mem stage]
 		//				==input==
 		//				==output=
-		.memtoregM(memtoregM),		.memwriteM(memwriteM),
+		.memtoregM(memtoregM),		.memwriteE(memwriteE),
         .regToHilo_hiM(regToHilo_hiM),
         .regToHilo_loM(regToHilo_loM),
         .mdToHiloM(mdToHiloM),
 		.regwriteM(regwriteM),
         .hilotoregM(hilotoregM),    .hilowriteM(hilowriteM),
-        .hilosrcM(hilosrcM),
+        .hilosrcM(hilosrcM), 		.memReadWidthM(memReadWidthM),
+		.memLoadIsSignM(memLoadIsSignM),
 		//[writeBack stage]
 		//				==input==
 		//				==output=
@@ -95,6 +99,7 @@ module mips(
         .hilosrcE(hilosrcE),
         .mulOrdivE(mulOrdivE),
         .mdIsSignE(mdIsSignE),          .mdToHiloE(mdToHiloE),
+		.memwriteE(memwriteE),
 		//				==output=
 		.flushE(flushE),            .stallE(stallE),
 		//[mem stage]
@@ -105,9 +110,11 @@ module mips(
         .hilotoregM(hilotoregM),    .hilosrcM(hilosrcM),
         .regToHilo_hiM(regToHilo_hiM),
         .regToHilo_loM(regToHilo_loM),
-        .mdToHiloM(mdToHiloM),
+        .mdToHiloM(mdToHiloM),		.memReadWidthM(memReadWidthM),
+		.memLoadIsSignM(memLoadIsSignM),
 		//				==output=
-		.aluoutM(aluoutM),			.writedataM(writedataM),
+		.aluoutM(aluoutM),			.writedataExtendedM(writedataM),
+		.memwrite_filterdM(memwriteEN),
 		//[writeBack stage]
 		//				==input==
 		.memtoregW(memtoregW), 		.regwriteW(regwriteW),

--- a/inst52/myCPU/mycpu_top.v
+++ b/inst52/myCPU/mycpu_top.v
@@ -19,7 +19,7 @@ module mycpu_top(
 // 一个例子
 	wire [31:0] pc;
 	wire [31:0] instr;
-	wire memwrite;
+	wire [3:0] memwrite;
 	wire [31:0] aluout, writedata, readdata;
     mips mips(
         .clk(clk),
@@ -44,7 +44,7 @@ module mycpu_top(
 
     assign data_sram_en = 1'b1;     //如果有data_en，就用data_en
     // TODO: 四个1就写入，是因为现在默认是以一个word为单位。之后要有写入半字等操作，到时候就要修改了
-    assign data_sram_wen = {4{memwrite}};
+    assign data_sram_wen = memwrite;
     assign data_sram_addr = aluout;
     assign data_sram_wdata = writedata;
     assign readdata = data_sram_rdata;

--- a/inst52/myCPU/mycpu_top.v
+++ b/inst52/myCPU/mycpu_top.v
@@ -30,7 +30,7 @@ module mycpu_top(
         .instrF(instr),              //instrF
         //data
         // .data_en(data_en),
-        .memwriteM(memwrite),
+        .memwriteEN(memwrite),
         .aluoutM(aluout),
         .writedataM(writedata),
         .readdataM(readdata)
@@ -43,7 +43,7 @@ module mycpu_top(
     assign instr = inst_sram_rdata;
 
     assign data_sram_en = 1'b1;     //如果有data_en，就用data_en
-    // TODO: 四个1就写入，是因为现在默认是以一个word为单位。之后要有写入半字等操作，到时候就要修改了
+    // 读入时，就算是只读半字，也需要读入整个word（即memwrite的四位都为0），然后再根据类型选择要读的有哪些部分
     assign data_sram_wen = memwrite;
     assign data_sram_addr = aluout;
     assign data_sram_wdata = writedata;

--- a/inst52/myCPU/utils/control_signal_define.vh
+++ b/inst52/myCPU/utils/control_signal_define.vh
@@ -23,3 +23,8 @@
 `define memWrite_HALF       4'b0011
 `define memWrite_BYTE       4'b0001
 `define memWrite_OFF        4'b0000
+
+`define memReadWidth_WORD       4'b1111
+`define memReadWidth_HALF       4'b0011
+`define memReadWidth_BYTE       4'b0001
+`define memReadWidth_OFF        4'b0000

--- a/inst52/myCPU/utils/control_signal_define.vh
+++ b/inst52/myCPU/utils/control_signal_define.vh
@@ -18,3 +18,8 @@
 
 `define mulOrdiv_MUL        1'b1
 `define mulOrdiv_DIV        1'b0
+
+`define memWrite_WORD       4'b1111
+`define memWrite_HALF       4'b0011
+`define memWrite_BYTE       4'b0001
+`define memWrite_OFF        4'b0000

--- a/inst52/myCPU/utils/memload_filter.v
+++ b/inst52/myCPU/utils/memload_filter.v
@@ -1,0 +1,67 @@
+`include "./control_signal_define.vh"
+`timescale 1ns / 1ps
+
+module memload_filter #(parameter WIDTH = 32)(
+    input [WIDTH-1:0] addr,
+    input [WIDTH-1:0] memLoadData,
+    input [3:0] memReadWidth,
+    input memLoadIsSign,
+    output reg [WIDTH-1:0] loadDataFiltered
+    );
+
+    // 根据addr的偏移来确定LH是低半字还是高半字
+    //                  LB是哪个字节
+    // 例如，如果addr是10，那么LH就是高半字（也可以看作将原本的0011左移两位，变成1100）
+    // 再例如，如果addr是11，那么LB就是最高的那个字节（也可以看作将原本的0001左移三位，变成1000）
+    // wire [3:0] memReadMask = memReadWidth << addr[1:0];
+    reg [3:0] memReadMask;
+
+    always @(*) begin
+        memReadMask = memReadWidth << addr[1:0];
+        case(memReadWidth)
+            `memReadWidth_WORD: loadDataFiltered = memLoadData[31:0];
+            `memReadWidth_HALF: begin
+                case(memReadMask)
+                    4'b0011:   begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{16{memLoadData[15]}}, memLoadData[15:0]} :
+                            {{16{1'b0}}, memLoadData[15:0]};
+                    end
+                    4'b1100:   begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{16{memLoadData[31]}}, memLoadData[31:16]} :
+                            {{16{1'b0}}, memLoadData[31:16]};
+                    end
+                    default:   loadDataFiltered = memLoadData; // 按理说不应出现这种情况，可能需要例外
+                endcase
+            end
+            `memReadWidth_BYTE: begin
+                case(memReadMask)
+                    4'b0001: begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{24{memLoadData[7]}}, memLoadData[7:0]} :
+                            {{24{1'b0}}, memLoadData[7:0]};
+                    end
+                    4'b0010: begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{24{memLoadData[15]}}, memLoadData[15:8]} :
+                            {{24{1'b0}}, memLoadData[15:8]};
+                    end
+                    4'b0100: begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{24{memLoadData[23]}}, memLoadData[23:16]} :
+                            {{24{1'b0}}, memLoadData[23:16]};
+                    end
+                    4'b1000: begin
+                        loadDataFiltered = (memLoadIsSign) ?
+                            {{24{memLoadData[31]}}, memLoadData[31:24]} :
+                            {{24{1'b0}}, memLoadData[31:24]};
+                    end
+                    default:   loadDataFiltered = memLoadData; // 按理说不应出现这种情况，可能需要例外
+                endcase
+            end
+            default:           loadDataFiltered = memLoadData;
+        endcase
+    end
+
+endmodule

--- a/inst52/myCPU/utils/memwrite_extend.v
+++ b/inst52/myCPU/utils/memwrite_extend.v
@@ -1,0 +1,17 @@
+`include "./control_signal_define.vh"
+`timescale 1ns / 1ps
+
+module memwrite_extend #(parameter WIDTH = 32)(
+    input [WIDTH-1:0] writedata,
+    input [3:0] memwriteEN,
+    output reg [WIDTH-1:0] extended
+    );
+
+    always@ (*) begin
+        case(memwriteEN)
+            `memWrite_HALF: extended = {writedata[15:0], writedata[15:0]};
+            `memWrite_BYTE: extended = {writedata[7:0], writedata[7:0], writedata[7:0], writedata[7:0]};
+            default:        extended = writedata;
+        endcase
+    end
+endmodule

--- a/inst52/myCPU/utils/memwrite_filter.v
+++ b/inst52/myCPU/utils/memwrite_filter.v
@@ -1,0 +1,37 @@
+`include "./control_signal_define.vh"
+`timescale 1ns / 1ps
+
+module memwrite_filter #(parameter WIDTH = 32)(
+    input [WIDTH-1:0] addr,
+    input [3:0] memwriteEN,
+    output reg [3:0] memwriteEN_filterd
+    );
+
+    // 根据addr的偏移来确定SH是低半字还是高半字
+    //                  SB是哪个字节
+    // 例如，如果addr是10，那么SH就是高半字（也可以看作将原本的0011左移两位，变成1100）
+    // 再例如，如果addr是11，那么SB就是最高的那个字节（也可以看作将原本的0001左移三位，变成1000）
+
+    always@ (*) begin
+        case(memwriteEN)
+            `memWrite_WORD: memwriteEN_filterd = `memWrite_WORD;
+            `memWrite_HALF: begin
+                case(addr[1:0])
+                    2'b00:   memwriteEN_filterd = `memWrite_HALF;
+                    2'b10:   memwriteEN_filterd = `memWrite_HALF << 2;
+                    default: memwriteEN_filterd = 4'b0000; // 按理说不应该发生，需要例外
+                endcase
+            end
+            `memWrite_BYTE: begin
+                case(addr[1:0])
+                    2'b00:   memwriteEN_filterd = `memWrite_BYTE;
+                    2'b01:   memwriteEN_filterd = `memWrite_BYTE << 1;
+                    2'b10:   memwriteEN_filterd = `memWrite_BYTE << 2;
+                    2'b11:   memwriteEN_filterd = `memWrite_BYTE << 3;
+                    default: memwriteEN_filterd = 4'b0000; // 按理说不应该发生，需要例外
+                endcase
+            end
+            default:        memwriteEN_filterd = `memWrite_OFF;
+        endcase
+    end
+endmodule


### PR DESCRIPTION
# SW，SH，SB

信号上，将`MemWrite`扩充成4位。

- 对于SW指令，本身就是写入一个字，无需判断
- 对于SH指令，写入的内容是rt寄存器的低半字。但由于写入地址是按字节编址，每次写入又一定是写入32位，因此需要先将低半字（如3f3f）扩充到一个字（3f3f），并注意MemWrite写使能哪几位设为1。例如，如果写入地址最后两位为00，那么MemWrite为0011，如果写入地址最后两位为10，那么MemWrite为1100。
- 对于SB指令，写入的内容是rt寄存器的最低字节。但由于写入地址是按字节编址，每次写入又一定是写入32位，因此需要先将字节（如ab）扩充到一个字（abababab），并注意MemWrite写使能哪几位设为1。例如，如果写入地址最后两位为00，那么MemWrite为0001，如果写入地址最后两位为11，那么MemWrite为1000。

以上所说的“扩充”和“判断MemWrite”，都是在MEM阶段，写入内存之前发生的。为此添加了模块`memwrite_extend`（用于扩成32位）与`memwrite_filter`（用于根据地址调整memWrite）。

# LW，LHU，LH，LBU，LB

信号上，首先定义了`memReadWidth`用于读取数据宽度（注意，读取时memWrite仍然为全0。是读取整字之后再根据宽度取出想要的部分）

以及定义了`memLoadIsSign`来判断读取后扩充时是否是有符号扩充。

- 对于LW指令，直接读取整字即可
- 对于LH/LHU指令，读取的内容为整字，随后需要根据需要读取是高位半字还是低位半字。和Save类指令的描述类似，也是由于地址是按字节编址，需通过低2位的offset来判断。读取完半字后，再根据`memLoadIsSign`进行有符号或无符号扩充。
- 对于LB/LBU指令同理，读取整字，选字节，进行有符号或无符号扩充。

以上所说的“判断MemReadWidth”与“扩充”，都是在WRITEBACK阶段，已通过memtoreg信号和hilotoreg信号决定了写回内存之后发生的。为此添加了模块`memload_filter`（扩充和判断二合一）