### PR TITLE
Final5inst

### DIFF
--- a/inst52/myCPU/controller/aludec.v
+++ b/inst52/myCPU/controller/aludec.v
@@ -15,9 +15,9 @@ module aludec(
             `R_TYPE: case(funct)
                 // 算术运算
                 `ADD: aluctrl = `ADD_CONTROL;
-                `ADDU: aluctrl = `ADD_CONTROL;
+                `ADDU: aluctrl = `ADDU_CONTROL;
                 `SUB: aluctrl = `SUB_CONTROL;
-                `SUBU: aluctrl = `SUB_CONTROL;
+                `SUBU: aluctrl = `SUBU_CONTROL;
                 `SLT: aluctrl = `SLT_CONTROL;
                 `SLTU: aluctrl = `SLTU_CONTROL;
                 // 逻辑运算
@@ -42,7 +42,8 @@ module aludec(
             `ORI: aluctrl = `OR_CONTROL;
             `XORI: aluctrl = `XOR_CONTROL;
             `ANDI: aluctrl = `AND_CONTROL;
-            `ADDI, `ADDIU: aluctrl = `ADD_CONTROL;
+            `ADDI: aluctrl = `ADD_CONTROL;
+            `ADDIU: aluctrl = `ADDU_CONTROL;
             `SLTI, `SLTIU: aluctrl = `SLT_CONTROL;
             default: aluctrl = `AND_CONTROL;
         endcase

--- a/inst52/myCPU/controller/maindec.v
+++ b/inst52/myCPU/controller/maindec.v
@@ -294,10 +294,10 @@ module maindec(
     always @(*)begin
         case(op)
             `R_TYPE:case(funct)
-                    `ADD,`ADDI,`SUB,`SUBU,
+                    `ADD,`ADDU,`SUB,`SUBU,
                     `SLT,`SLTU,`DIV,`DIVU,
                     `MULT,`MULTU,`AND,`NOR,
-                    `OR,`ORI,`SLLV,`SLL,
+                    `OR,`XOR,`SLLV,`SLL,
                     `SRAV,`SRA,`SRLV,`SRL,
                     `JALR,`JR,`MFHI,`MFLO,
                     `MTLO,`MTHI,`BREAK,`SYSCALL: invalid = 1'b0;

--- a/inst52/myCPU/datapath/hazard.v
+++ b/inst52/myCPU/datapath/hazard.v
@@ -34,6 +34,8 @@ module hazard(
     input regToHilo_hiM,regToHilo_loM,mdToHiloM,
     input isWritecp0M,
     input [4:0] writecp0AddrM,
+    input [31:0] except_typeM,cp0_epcM,
+    output reg [31:0] newPCM,
 
 	//write back stage
 	input [4:0] writeregW,
@@ -103,4 +105,19 @@ module hazard(
 	assign flushE = lwstallD | branchstallD | jrstall_READ;
     assign stallE = stall_divE;
 
+    // 根据当前得到的例外类型跳转到例外处理程序入口（除了ERET外，都统一跳到0xBFC00380）
+    always @(*) begin
+        if(except_typeM != 32'b0) begin
+            case(except_typeM)
+                32'h00000001:begin newPCM <= 32'hBFC00380; end
+                32'h00000004:begin newPCM <= 32'hBFC00380; end
+                32'h00000005:begin newPCM <= 32'hBFC00380; end
+                32'h00000008:begin newPCM <= 32'hBFC00380; end
+                32'h00000009:begin newPCM <= 32'hBFC00380; end
+                32'h0000000a:begin newPCM <= 32'hBFC00380; end
+                32'h0000000c:begin newPCM <= 32'hBFC00380; end
+                32'h0000000e:begin newPCM <= cp0_epcM; end
+            endcase
+        end
+    end
 endmodule

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -12,6 +12,7 @@ module mips(
 
 	wire [5:0] opD,functD;
 	wire [4:0] rsD,rtD,rdD;
+    wire invalidD;
 	wire regdstE,alusrcE,branchD,jalD,jrD,pcsrcD,memtoregE,memtoregM,memtoregW;
 	wire balE,jalE,jrE,regwriteE,regwriteM,regwriteW;
 	wire [4:0] alucontrolE;
@@ -22,9 +23,13 @@ module mips(
     wire hilotoregM,hilotoregW;
 	wire hilowriteM,hilosrcM;
     wire hilosrcE;
+    wire isWritecp0E,isWritecp0M;
 	wire [3:0] memwriteE;
+    wire [4:0] writecp0AddrE,writecp0AddrM,readcp0AddrE;
 	wire [3:0] memReadWidthM;
 	wire memLoadIsSignM;
+    wire cp0ToRegE,cp0ToRegM,cp0ToRegW;
+    wire branchE,branchM,jumpE,jumpM,jalM,jrM,jalrE,jalrM;
 
 	controller c(
 		.clk(clk), .rst(rst),
@@ -40,7 +45,7 @@ module mips(
 		//				==output=
 		.pcsrcD(pcsrcD),			.branchD(branchD),
 		.jumpD(jumpD),				.jalD(jalD),
-		.jrD(jrD),
+		.jrD(jrD),                  .invalidD(invalidD),
 		//[execute stage]
 		//				==input==
 		.flushE(flushE),            .stallE(stallE),
@@ -55,6 +60,10 @@ module mips(
         .hilotoregE(hilotoregE),
         .hilosrcE(hilosrcE),
         .mdIsSignE(mdIsSignE),
+        .isWritecp0E(isWritecp0E),  .writecp0AddrE(writecp0AddrE),
+        .readcp0AddrE(readcp0AddrE),.cp0ToRegE(cp0ToRegE),
+        .branchE(branchE),          .jumpE(jumpE),
+        .jalrE(jalrE),
 		//[mem stage]
 		//				==input==
 		//				==output=
@@ -66,11 +75,15 @@ module mips(
         .hilotoregM(hilotoregM),    .hilowriteM(hilowriteM),
         .hilosrcM(hilosrcM), 		.memReadWidthM(memReadWidthM),
 		.memLoadIsSignM(memLoadIsSignM),
+        .isWritecp0M(isWritecp0M),  .writecp0AddrM(writecp0AddrM),
+        .cp0ToRegM(cp0ToRegM),      .branchM(branchM),
+        .jumpM(jumpM),              .jalM(jalM),
+        .jrM(jrM),                  .jalrM(jalrM),
 		//[writeBack stage]
 		//				==input==
 		//				==output=
 		.memtoregW(memtoregW),		.regwriteW(regwriteW),
-        .hilotoregW(hilotoregW)
+        .hilotoregW(hilotoregW),    .cp0ToRegW(cp0ToRegW)
 	);
 
 	datapath dp(
@@ -84,7 +97,8 @@ module mips(
 		//				==input==
 		.pcsrcD(pcsrcD),			.branchD(branchD),
 		.jumpD(jumpD),				.jalD(jalD),
-		.jrD(jrD),					.jrE(jrE),
+		.jrD(jrD),					
+        .invalidD(invalidD),
 		//				==output=
 		.validBranchConditionD(validBranchConditionD), 			.opD(opD),
 		.rsD(rsD),				.rtD(rtD),
@@ -94,12 +108,17 @@ module mips(
 		.memtoregE(memtoregE),		.alusrcE(alusrcE),
 		.regdstE(regdstE), 			.regwriteE(regwriteE),
 		.alucontrolE(alucontrolE), 	.balE(balE),
-		.jalE(jalE),
+		.jalE(jalE),                .jrE(jrE),
         .hilotoregE(hilotoregE),
         .hilosrcE(hilosrcE),
         .mulOrdivE(mulOrdivE),
         .mdIsSignE(mdIsSignE),          .mdToHiloE(mdToHiloE),
 		.memwriteE(memwriteE),
+        .isWritecp0E(isWritecp0E),  .writecp0AddrE(writecp0AddrE),
+        .readcp0AddrE(readcp0AddrE),.cp0ToRegE(cp0ToRegE),
+        .branchE(branchE),          .jumpE(jumpE),
+        .jalrE(jalrE),
+
 		//				==output=
 		.flushE(flushE),            .stallE(stallE),
 		//[mem stage]
@@ -112,13 +131,17 @@ module mips(
         .regToHilo_loM(regToHilo_loM),
         .mdToHiloM(mdToHiloM),		.memReadWidthM(memReadWidthM),
 		.memLoadIsSignM(memLoadIsSignM),
+        .isWritecp0M(isWritecp0M),  .writecp0AddrM(writecp0AddrM),
+        .cp0ToRegM(cp0ToRegM),      .branchM(branchM),
+        .jumpM(jumpM),              .jalM(jalM),
+        .jrM(jrM),                  .jalrM(jalrM),
 		//				==output=
 		.aluoutM(aluoutM),			.writedataExtendedM(writedataM),
 		.memwrite_filterdM(memwriteEN),
 		//[writeBack stage]
 		//				==input==
 		.memtoregW(memtoregW), 		.regwriteW(regwriteW),
-        .hilotoregW(hilotoregW)
+        .hilotoregW(hilotoregW),    .cp0ToRegW(cp0ToRegW)
 		//				==output=
 	);
 

--- a/inst52/myCPU/utils/alu.v
+++ b/inst52/myCPU/utils/alu.v
@@ -6,6 +6,7 @@ module alu(
     input [31:0]num2,
     input [4:0]sa,
     input [4:0]op,
+    input mdToHilo,
     output reg [31:0]result,
     output reg overflow //只考虑ADD、ADDI、SUB三条有符号算术运算指令的溢出
     );
@@ -18,12 +19,12 @@ module alu(
             `ADD_CONTROL: begin
                 result = num1 + num2;
                 temp = {num1[31],num1} + {num2[31],num2};
-                overflow = (temp[32]!=temp[31]);
+                overflow = (mdToHilo == 1'b0) ? (temp[32]!=temp[31]) : 1'b0;
             end
             `SUB_CONTROL: begin
                 result = num1 - num2;
                 temp = {num1[31],num1} - {num2[31],num2};
-                overflow = (temp[32]!=temp[31]);
+                overflow = (mdToHilo == 1'b0) ? (temp[32]!=temp[31]) : 1'b0;
             end
             `ADDU_CONTROL: begin
                 result = num1 + num2;

--- a/inst52/myCPU/utils/alu.v
+++ b/inst52/myCPU/utils/alu.v
@@ -6,11 +6,11 @@ module alu(
     input [31:0]num2,
     input [4:0]sa,
     input [4:0]op,
-    output reg [31:0]result
+    output reg [31:0]result,
+    output reg overflow //只考虑ADD、ADDI、SUB三条有符号算术运算指令的溢出
     );
 
     reg [32:0] temp; // 多了一位用于检验溢出
-    reg exception;
 
     always @(*) begin
         case(op)
@@ -18,29 +18,76 @@ module alu(
             `ADD_CONTROL: begin
                 result = num1 + num2;
                 temp = {num1[31],num1} + {num2[31],num2};
-                exception = (temp[32]!=temp[31]);
+                overflow = (temp[32]!=temp[31]);
             end
             `SUB_CONTROL: begin
                 result = num1 - num2;
                 temp = {num1[31],num1} - {num2[31],num2};
-                exception = (temp[32]!=temp[31]);
+                overflow = (temp[32]!=temp[31]);
             end
-            `SLT_CONTROL: result = ($signed(num1) < $signed(num2)) ? 1'b1 : 1'b0;
-            `SLTU_CONTROL: result = (num1 < num2) ? 1'b1 : 1'b0;
+            `ADDU_CONTROL: begin
+                result = num1 + num2;
+                overflow = 1'b0;
+            end
+            `SUBU_CONTROL: begin
+                result = num1 - num2;
+                overflow = 1'b0;
+            end
+            `SLT_CONTROL: begin 
+                result = ($signed(num1) < $signed(num2)) ? 1'b1 : 1'b0;
+                overflow = 1'b0;
+            end
+            `SLTU_CONTROL: begin
+                result = (num1 < num2) ? 1'b1 : 1'b0;
+                overflow = 1'b0;
+            end
             // 逻辑
-            `AND_CONTROL: result = num1 & num2;
-            `OR_CONTROL: result = num1 | num2;
-            `XOR_CONTROL: result = num1 ^ num2;
-            `NOR_CONTROL: result = ~(num1 | num2);
+            `AND_CONTROL: begin
+                result = num1 & num2;
+                overflow = 1'b0;
+            end
+            `OR_CONTROL: begin
+                result = num1 | num2;
+                overflow = 1'b0;
+            end
+            `XOR_CONTROL: begin
+                result = num1 ^ num2;
+                overflow = 1'b0;
+            end
+            `NOR_CONTROL: begin
+                result = ~(num1 | num2);
+                overflow = 1'b0;
+            end
             // 位移
-            `SLL_CONTROL: result = num2 << sa;
-            `SRL_CONTROL: result = num2 >> sa;
-            `SRA_CONTROL: result = $signed(num2) >>> sa;
-            `SLLV_CONTROL: result = num2 << num1[4:0];
-            `SRLV_CONTROL: result = num2 >> num1[4:0];
-            `SRAV_CONTROL: result = $signed(num2) >>> num1[4:0];
+            `SLL_CONTROL: begin
+                result = num2 << sa;
+                overflow = 1'b0;
+            end
+            `SRL_CONTROL: begin
+                result = num2 >> sa;
+                overflow = 1'b0;
+            end
+            `SRA_CONTROL: begin
+                result = $signed(num2) >>> sa;
+                overflow = 1'b0;
+            end
+            `SLLV_CONTROL: begin
+                result = num2 << num1[4:0];
+                overflow = 1'b0;
+            end
+            `SRLV_CONTROL: begin
+                result = num2 >> num1[4:0];
+                overflow = 1'b0;
+            end
+            `SRAV_CONTROL: begin
+                result = $signed(num2) >>> num1[4:0];
+                overflow = 1'b0;
+            end
             // ...
-            default: result = 32'hxxxx_xxxx;
+            default: begin
+                result = 32'hxxxx_xxxx;
+                overflow = 1'b0;
+            end
         endcase
     end
 // assign result =

--- a/inst52/myCPU/utils/cp0_reg.v
+++ b/inst52/myCPU/utils/cp0_reg.v
@@ -1,0 +1,220 @@
+`timescale 1ns / 1ps
+`include "defines2.vh"
+
+module cp0_reg(
+	input wire clk,
+	input wire rst,
+
+	input wire we_i,
+	input[4:0] waddr_i,
+	input[4:0] raddr_i,
+	input[`RegBus] data_i,
+
+	input wire[5:0] int_i,
+
+	input wire[`RegBus] excepttype_i,
+	input wire[`RegBus] current_inst_addr_i,
+	input wire is_in_delayslot_i,
+	input wire[`RegBus] bad_addr_i,
+
+	output wire[`RegBus] count_o,
+	output reg [`RegBus] data_o,
+	output reg [`RegBus] compare_o,
+	output reg [`RegBus] status_o,
+	output reg [`RegBus] cause_o,
+	output reg [`RegBus] epc_o,
+	output reg [`RegBus] config_o,
+	output reg [`RegBus] prid_o,
+	output reg [`RegBus] badvaddr,
+	output reg           timer_int_o
+    );
+
+	reg[32:0] count;
+	assign count_o = count[32:1];
+	
+	always @(posedge clk) begin
+		if(rst == `RstEnable) begin
+			count <= 0;
+			compare_o <= `ZeroWord;
+			status_o <= 32'b00010000000000000000000000000000;
+			cause_o <= `ZeroWord;
+			epc_o <= `ZeroWord;
+			config_o <= 32'b00000000000000001000000000000000;
+			prid_o <= 32'b00000000010011000000000100000010;
+			timer_int_o <= `InterruptNotAssert;
+		end else begin
+			count <= count + 1;
+			cause_o[15:10] <= int_i;
+			if(compare_o != `ZeroWord && count_o == compare_o) begin
+				/* code */
+				timer_int_o <= `InterruptAssert;
+			end
+			if(we_i == `WriteEnable) begin
+				/* code */
+				case (waddr_i)
+					`CP0_REG_COUNT:begin 
+						count[32:1] <= data_i;
+					end
+					`CP0_REG_COMPARE:begin 
+						compare_o <= data_i;
+						timer_int_o <= `InterruptNotAssert;
+					end
+					`CP0_REG_STATUS:begin 
+						status_o <= data_i;
+					end
+					`CP0_REG_CAUSE:begin 
+						cause_o[9:8] <= data_i[9:8];
+						cause_o[23] <= data_i[23];
+						cause_o[22] <= data_i[22];
+					end
+					`CP0_REG_EPC:begin 
+						epc_o <= data_i;
+					end
+					default : /* default */;
+				endcase
+			end
+			case (excepttype_i)
+				32'h00000001:begin // 中断（其实写入的cause为0）
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b00000;
+				end
+				32'h00000004:begin // 取指非对齐或Load非对齐
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b00100;
+					badvaddr <= bad_addr_i;
+				end
+				32'h00000005:begin // Store非对齐
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b00101;
+					badvaddr <= bad_addr_i;
+				end
+				32'h00000008:begin // Syscall异常
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b01000;
+				end
+				32'h00000009:begin // BREAK异常
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b01001;
+				end
+				32'h0000000a:begin // 保留指令（译码失败）
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b01010;
+				end
+				32'h0000000c:begin // ALU溢出异常
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b01100;
+				end
+				32'h0000000d:begin // 自陷指令（不在57条中）
+					if(is_in_delayslot_i == `InDelaySlot) begin
+						/* code */
+						epc_o <= current_inst_addr_i - 4;
+						cause_o[31] <= 1'b1;
+					end else begin 
+						epc_o <= current_inst_addr_i;
+						cause_o[31] <= 1'b0;
+					end
+					status_o[1] <= 1'b1;
+					cause_o[6:2] <= 5'b01101;
+				end
+				32'h0000000e:begin // eret异常（准确说不叫异常，但通过这个在跳转到epc的同时清零status的EXL）
+					status_o[1] <= 1'b0;
+				end
+				default : /* default */;
+			endcase
+		end
+	end
+
+	always @(*) begin
+		if(rst == `RstEnable) begin
+			/* code */
+			data_o <= `ZeroWord;
+		end else begin 
+			case (raddr_i)
+				`CP0_REG_COUNT:begin 
+					data_o <= count_o;
+				end
+				`CP0_REG_COMPARE:begin 
+					data_o <= compare_o;
+				end
+				`CP0_REG_STATUS:begin 
+					data_o <= status_o;
+				end
+				`CP0_REG_CAUSE:begin 
+					data_o <= cause_o;
+				end
+				`CP0_REG_EPC:begin 
+					data_o <= epc_o;
+				end
+				`CP0_REG_PRID:begin 
+					data_o <= prid_o;
+				end
+				`CP0_REG_CONFIG:begin 
+					data_o <= config_o;
+				end
+				`CP0_REG_BADVADDR:begin 
+					data_o <= badvaddr;
+				end
+				default : begin 
+					data_o <= `ZeroWord;
+				end
+			endcase
+		end
+	
+	end
+endmodule

--- a/inst52/myCPU/utils/exception_type.v
+++ b/inst52/myCPU/utils/exception_type.v
@@ -1,0 +1,40 @@
+`timescale 1ns / 1ps
+
+module exception_type(
+    input rst,
+    input [7:0] except,
+    input [31:0] cp0_status,cp0_cause,
+    output reg [31:0] except_type
+    );
+    always @(*)begin
+        if(rst) begin
+            except_type <= 32'b0;
+        end
+        else if((cp0_status[15:8] & cp0_cause[15:8] != 8'h00) && 
+                        (cp0_status[1] == 1'b0 && (cp0_status[0] == 1'b1))) begin
+                            except_type <= 32'h00000001;//中断
+                        end 
+        else if(except[7] == 1'b1 || except[1] == 1'b1) begin
+            except_type <= 32'h00000004;//ADEL
+        end
+        else if(except[0] == 1'b1) begin
+            except_type <= 32'h00000005;//ADSL
+        end
+        else if(except[5] == 1'b1) begin
+            except_type <= 32'h00000008;//Sys
+        end
+        else if(except[6] == 1'b1) begin
+            except_type <= 32'h00000009;//Bp
+        end
+        else if(except[4] == 1'b1) begin
+            except_type <= 32'h0000000e;//Eret
+        end
+        else if(except[3] == 1'b1) begin
+            except_type <= 32'h0000000a;//RI
+        end
+        else if(except[2] == 1'b1) begin
+            except_type <= 32'h0000000c;//Ov
+        end
+    end
+    
+endmodule

--- a/inst52/myCPU/utils/mux4.v
+++ b/inst52/myCPU/utils/mux4.v
@@ -1,0 +1,13 @@
+`timescale 1ns / 1ps
+
+module mux4#(parameter WIDTH=32)(
+    input [WIDTH-1:0] sel_0,sel_1,sel_2,sel_3,
+    input [2:0] sel_signal,
+    output [WIDTH-1:0] sel_result
+    );
+    assign sel_result = (sel_signal == 3'b000) ? sel_0 :
+						(sel_signal == 3'b001) ? sel_1 :
+						(sel_signal == 3'b010) ? sel_2 :
+                        (sel_signal == 3'b100) ? sel_3 :
+						sel_0;
+endmodule


### PR DESCRIPTION
完成最后五条特权指令，主要改动如下：
1、新增cp0_reg模块、mux4模块、exception_type模块
2、由于新增mfc0指令也将cp0寄存器的值写给reg_file，故新增cp0ToReg信号，此外还有一些其它控制信号：是否写CP0寄存器、CP0寄存器的写地址与读地址等
3、在取指令IF、指令译码ID、alu执行Exe、数据访存Mem依次检测8中例外信号，并统一在Mem阶段处理
4、引进的CP0寄存器在Exe读、在Mem写，同样会导致数据冒险，故hazard模块新增forwardCP0控制信号
5、当检测到例外时，需要跳转到例外处理程序，其入口地址统一为（BFC00380），这里设计为由hazard模块在Mem阶段产生跳转地址，并传给pc模块（注：除了ERET外，都统一跳到0xBFC00380）
……