### PR TITLE
完成【连接SRAM-SOC】

### DIFF
--- a/inst52/myCPU/controller/controller.v
+++ b/inst52/myCPU/controller/controller.v
@@ -31,6 +31,7 @@ module controller(
 
 
 	//mem stage
+	input flushM,
 	output memtoregM,regwriteM,hilowriteM,regToHilo_hiM,regToHilo_loM,mdToHiloM,hilotoregM,hilosrcM,isWritecp0M,cp0ToRegM,branchM,jumpM,jalM,jrM,jalrM,
 	output [3:0] memReadWidthM,
 	output memLoadIsSignM,
@@ -38,6 +39,7 @@ module controller(
 	output data_sram_enM,
 
 	//write back stage
+	input flushW,
 	output memtoregW,regwriteW,hilotoregW,cp0ToRegW
 );
 
@@ -76,8 +78,8 @@ module controller(
 	);
 
 	// [execute -> mem]
-	flopr #(26) regM(
-		clk,rst,
+	floprc #(26) regM(
+		clk,rst,flushM,
 		{memtoregE,memReadWidthE,//5bit
 		regwriteE,regToHilo_hiE,regToHilo_loE,mdToHiloE,hilowriteE,hilotoregE,//11bit
 		hilosrcE,memLoadIsSignE,isWritecp0E,writecp0AddrE,cp0ToRegE,branchE,jumpE,jalE,jrE,jalrE,data_sram_enE},//26bit
@@ -88,8 +90,8 @@ module controller(
 	);
 
 	// [mem -> writeBack]
-	flopr #(4) regW(
-		clk,rst,
+	floprc #(4) regW(
+		clk,rst,flushW,
 		{memtoregM,regwriteM,hilotoregM,cp0ToRegM},
 		{memtoregW,regwriteW,hilotoregW,cp0ToRegW}
 	);

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -514,7 +514,10 @@ module datapath(
 	// [Memory] 在向内存写入之前，需要将写入数据扩展成32位
 	memwrite_extend memwrite_extend(writedataM, memwriteM, writedataExtendedM);
 	// [Memory] 在向内存写入之前，如果是SW指令还需要进行写入地址的选择
-	memwrite_filter memwrite_filter(aluoutM,memwriteM,memwrite_filterdM);
+	//			【提醒】如果存在例外0(ades)，那么写入地址是错误的，因此需要把写入给取消
+	wire [3:0] memwrite_safeM;
+	assign memwrite_safeM = (checkExceptionM[0] == 1'b1) ? 4'b0000 : memwriteM;
+	memwrite_filter memwrite_filter(aluoutM,memwrite_safeM,memwrite_filterdM);
 
 
     // [Memory] 得到当前（优先级最高）的例外类型

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -296,7 +296,7 @@ module datapath(
     flopr #(1) r21M(clk,rst,cp0_timer_intE,cp0_timer_intM);
     flopr r22M(clk,rst,pcE,pcM);
     flopr #(1) r23M(clk,rst,isInDelayslotE,isInDelayslotM);
-    flopr #(8) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
+    flopr #(6) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE},checkExceptionM[7:2]);
     // 更新hilo_reg前，确定HI、LO
     mux3 mux_HI2M(HIM,mdResult_hiM,srcaM,{regToHilo_hiM,mdToHiloM},HI2M);
     mux3 mux_LO2M(LOM,mdResult_loM,srcaM,{regToHilo_loM,mdToHiloM},LO2M);
@@ -504,12 +504,12 @@ module datapath(
     mux2 mux_rddst(LO2M,HI2M,hilosrcM,hilooutM);
     // [memory] 如果需要与内存读写数据，需要标记数据读写类型与读写地址是否正确
     // 			读数据
-    assign checkExceptionM[1] = (memReadWidthM == `memReadWidth_WORD & aluoutM[1:0] != 2'b00) ? 1'b1 :
-                                (memReadWidthM == `memReadWidth_HALF & (aluoutM[1:0] != 2'b00 | aluoutM[1:0] != 2'b10)) ? 1'b1 :
+    assign checkExceptionM[1] = (memReadWidthM == `memReadWidth_WORD && aluoutM[1:0] != 2'b00) ? 1'b1 :
+                                (memReadWidthM == `memReadWidth_HALF && (aluoutM[1:0] == 2'b11 || aluoutM[1:0] == 2'b01)) ? 1'b1 :
                                 1'b0;
     // 			写数据
-    assign checkExceptionM[0] = (memwriteM == `memWrite_WORD & aluoutM[1:0] != 2'b00) ? 1'b1 :
-                                (memwriteM == `memWrite_HALF & (aluoutM[1:0] != 2'b00 | aluoutM[1:0] != 2'b10)) ? 1'b1 :
+    assign checkExceptionM[0] = (memwriteM == `memWrite_WORD && aluoutM[1:0] != 2'b00) ? 1'b1 :
+                                (memwriteM == `memWrite_HALF && (aluoutM[1:0] == 2'b11 || aluoutM[1:0] == 2'b01)) ? 1'b1 :
                                 1'b0;
 	// [Memory] 在向内存写入之前，需要将写入数据扩展成32位
 	memwrite_extend memwrite_extend(writedataM, memwriteM, writedataExtendedM);

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -137,10 +137,10 @@ module datapath(
 
 	// [fetch -> decode]
 	// 暂存
-	flopenr r1D(clk,rst,~stallD,pc_plus4F,pc_plus4D);
-	flopenr r2D(clk,rst,~stallD,instrF,instrD);
-    flopenr r4D(clk,rst,~stallD,pcF,pcD);
-    flopenr #(8) exceptionF2D(clk,rst,~stallD,{checkExceptionF[7],7'd0},checkExceptionD);
+	flopenrc r1D(clk,rst,~stallD,flushD,pc_plus4F,pc_plus4D);
+	flopenrc r2D(clk,rst,~stallD,flushD,instrF,instrD);
+    flopenrc r4D(clk,rst,~stallD,flushD,pcF,pcD);
+    flopenrc #(8) exceptionF2D(clk,rst,~stallD,flushD,{checkExceptionF[7],7'd0},checkExceptionD);
 	// 前推
 	// D阶段要读rs，那么看是否需要有会写入rs寄存器的指令在MEM阶段，如果有就前推
 	// 如果要前推，如果是从hilo寄存器写入rs，那么就推hilooutM
@@ -217,28 +217,28 @@ module datapath(
 
 	// [execute -> mem]
 	// 暂存
-	flopr r1M(clk,rst,srcb2E,writedataM);
-	flopr r2M(clk,rst,aluoutE,aluoutM);
-	flopr #(5) r3M(clk,rst,writeregE,writeregM);
-    flopr r5M(clk,rst,srca2E,srcaM);
-    flopr r6M(clk,rst,HI2E,HIM);
-    flopr r7M(clk,rst,LO2E,LOM);
-    flopr r8M(clk,rst,mdResult_hiE,mdResult_hiM);
-    flopr r9M(clk,rst,mdResult_loE,mdResult_loM);
-	flopr #(4) r10M(clk,rst,memwriteE,memwriteM);
-    flopr r11M(clk,rst,srcb3E,srcbM);
-    flopr r12M(clk,rst,cp0_data2E,cp0_dataM);
-    flopr r14M(clk,rst,cp0_countE,cp0_countM);
-    flopr r15M(clk,rst,cp0_compareE,cp0_compareM);
-    flopr r16M(clk,rst,cp0_statusE,cp0_causeM);
-    flopr r17M(clk,rst,cp0_causeE,cp0_causeM);
-    flopr r18M(clk,rst,cp0_epcE,cp0_epcM);
-    flopr r19M(clk,rst,cp0_configE,cp0_configM);
-    flopr r20M(clk,rst,cp0_badvaddrE,cp0_badvaddrM);
-    flopr #(1) r21M(clk,rst,cp0_timer_intE,cp0_timer_intM);
-    flopr r22M(clk,rst,pcE,pcM);
-    flopr #(1) r23M(clk,rst,isInDelayslotE,isInDelayslotM);
-    flopr #(8) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
+	floprc r1M(clk,rst,flushM,srcb2E,writedataM);
+	floprc r2M(clk,rst,flushM,aluoutE,aluoutM);
+	floprc #(5) r3M(clk,rst,flushM,writeregE,writeregM);
+    floprc r5M(clk,rst,flushM,srca2E,srcaM);
+    floprc r6M(clk,rst,flushM,HI2E,HIM);
+    floprc r7M(clk,rst,flushM,LO2E,LOM);
+    floprc r8M(clk,rst,flushM,mdResult_hiE,mdResult_hiM);
+    floprc r9M(clk,rst,flushM,mdResult_loE,mdResult_loM);
+	floprc #(4) r10M(clk,rst,flushM,memwriteE,memwriteM);
+    floprc r11M(clk,rst,flushM,srcb3E,srcbM);
+    floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
+    floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
+    floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
+    floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
+    floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
+    floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
+    floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);
+    floprc r20M(clk,rst,flushM,cp0_badvaddrE,cp0_badvaddrM);
+    floprc #(1) r21M(clk,rst,flushM,cp0_timer_intE,cp0_timer_intM);
+    floprc r22M(clk,rst,flushM,pcE,pcM);
+    floprc #(1) r23M(clk,rst,flushM,isInDelayslotE,isInDelayslotM);
+    floprc #(8) exceptionE2M(clk,rst,flushM,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
     // 更新hilo_reg前，确定HI、LO
     mux3 mux_HI2M(HIM,mdResult_hiM,srcaM,{regToHilo_hiM,mdToHiloM},HI2M);
     mux3 mux_LO2M(LOM,mdResult_loM,srcaM,{regToHilo_loM,mdToHiloM},LO2M);
@@ -246,14 +246,14 @@ module datapath(
 
 	// [mem -> writeBack]
 	// 暂存
-	flopr r1W(clk,rst,aluoutM,aluoutW);
-	flopr r2W(clk,rst,readdataM,readdataW);
-	flopr #(5) r3W(clk,rst,writeregM,writeregW);
-    flopr r4W(clk,rst,hilooutM,hilooutW);
-	flopr #(4) r5W(clk,rst,memReadWidthM,memReadWidthW);
-	flopr #(1) r6W(clk,rst,memLoadIsSignM,memLoadIsSignW);
-    flopr r7W(clk,rst,cp0_dataM,cp0_dataW);
-	flopr r8W(clk,rst,pcM,pcW);
+	floprc r1W(clk,rst,flushW,aluoutM,aluoutW);
+	floprc r2W(clk,rst,flushW,readdataM,readdataW);
+	floprc #(5) r3W(clk,rst,flushW,writeregM,writeregW);
+    floprc r4W(clk,rst,flushW,hilooutM,hilooutW);
+	floprc #(4) r5W(clk,rst,flushW,memReadWidthM,memReadWidthW);
+	floprc #(1) r6W(clk,rst,flushW,memLoadIsSignM,memLoadIsSignW);
+    floprc r7W(clk,rst,flushW,cp0_dataM,cp0_dataW);
+	floprc r8W(clk,rst,flushW,pcM,pcW);
 
 
 	// =============================
@@ -328,7 +328,7 @@ module datapath(
 	wire [31:0] pc_next_addr;
 
 	// [Fetch] PC 模块
-	flopenr_pc pcreg(clk,rst,~stallF,pc_next_addr,pcF);
+	flopenr_pc pcreg(clk,rst,~stallF,flushF,pc_next_addr,newPCM,pcF);
     // [fetch] 标记取指令的地址是否对齐，不对齐产生例外
     assign checkExceptionF = (pcF[1:0]==2'b00) ? 8'd0 : 8'b1000_0000;
 	// [Fetch] PC + 4

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -42,6 +42,7 @@ module datapath(
     input branchM,jumpM,jalM,jrM,jalrM,
 	output [31:0] aluoutM,writedataExtendedM,
 	output [3:0] memwrite_filterdM,
+	output flushM,
 	//writeback stage
 	input memtoregW,
 	input regwriteW,
@@ -49,7 +50,8 @@ module datapath(
     input cp0ToRegW,
     output [31:0] pcW,
     output [4:0] writeregW,
-    output [31:0] result_filterdW
+    output [31:0] result_filterdW,
+	output flushW
 );
 
     //测试数据，暂时用于代表乘法结果与除法结果
@@ -117,14 +119,12 @@ module datapath(
     wire [31:0] badAddrM;
     wire [31:0] newPCM;
 	wire [7:0] checkExceptionM;
-	wire flushM;
 
 	//writeback stage
 	wire [31:0] aluoutW,readdataW,resultW,hilooutW;
 	wire [3:0] memReadWidthW;
 	wire memLoadIsSignW;
     wire [31:0] cp0_dataW;
-	wire flushW;
 
 
 
@@ -251,52 +251,52 @@ module datapath(
 
 	// [execute -> mem]
 	// 暂存
-	// floprc r1M(clk,rst,flushM,srcb2E,writedataM);
-	// floprc r2M(clk,rst,flushM,aluoutE,aluoutM);
-	// floprc #(5) r3M(clk,rst,flushM,writeregE,writeregM);
-    // floprc r5M(clk,rst,flushM,srca2E,srcaM);
-    // floprc r6M(clk,rst,flushM,HI2E,HIM);
-    // floprc r7M(clk,rst,flushM,LO2E,LOM);
-    // floprc r8M(clk,rst,flushM,mdResult_hiE,mdResult_hiM);
-    // floprc r9M(clk,rst,flushM,mdResult_loE,mdResult_loM);
-	// floprc #(4) r10M(clk,rst,flushM,memwriteE,memwriteM);
-    // floprc r11M(clk,rst,flushM,srcb3E,srcbM);
-    // floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
-    // floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
-    // floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
-    // floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
-    // floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
-    // floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
-    // floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);
-    // floprc r20M(clk,rst,flushM,cp0_badvaddrE,cp0_badvaddrM);
-    // floprc #(1) r21M(clk,rst,flushM,cp0_timer_intE,cp0_timer_intM);
-    // floprc r22M(clk,rst,flushM,pcE,pcM);
-    // floprc #(1) r23M(clk,rst,flushM,isInDelayslotE,isInDelayslotM);
-    // floprc #(8) exceptionE2M(clk,rst,flushM,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
+	floprc r1M(clk,rst,flushM,srcb2E,writedataM);
+	floprc r2M(clk,rst,flushM,aluoutE,aluoutM);
+	floprc #(5) r3M(clk,rst,flushM,writeregE,writeregM);
+    floprc r5M(clk,rst,flushM,srca2E,srcaM);
+    floprc r6M(clk,rst,flushM,HI2E,HIM);
+    floprc r7M(clk,rst,flushM,LO2E,LOM);
+    floprc r8M(clk,rst,flushM,mdResult_hiE,mdResult_hiM);
+    floprc r9M(clk,rst,flushM,mdResult_loE,mdResult_loM);
+	floprc #(4) r10M(clk,rst,flushM,memwriteE,memwriteM);
+    floprc r11M(clk,rst,flushM,srcb3E,srcbM);
+    floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
+    floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
+    floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
+    floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
+    floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
+    floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
+    floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);
+    floprc r20M(clk,rst,flushM,cp0_badvaddrE,cp0_badvaddrM);
+    floprc #(1) r21M(clk,rst,flushM,cp0_timer_intE,cp0_timer_intM);
+    floprc r22M(clk,rst,flushM,pcE,pcM);
+    floprc #(1) r23M(clk,rst,flushM,isInDelayslotE,isInDelayslotM);
+    floprc #(6) exceptionE2M(clk,rst,flushM,{checkExceptionE[7:3],ex_ovE},checkExceptionM[7:2]);
 
 
-	flopr r1M(clk,rst,srcb2E,writedataM);
-	flopr r2M(clk,rst,aluoutE,aluoutM);
-	flopr #(5) r3M(clk,rst,writeregE,writeregM);
-    flopr r5M(clk,rst,srca2E,srcaM);
-    flopr r6M(clk,rst,HI2E,HIM);
-    flopr r7M(clk,rst,LO2E,LOM);
-    flopr r8M(clk,rst,mdResult_hiE,mdResult_hiM);
-    flopr r9M(clk,rst,mdResult_loE,mdResult_loM);
-	flopr #(4) r10M(clk,rst,memwriteE,memwriteM);
-    flopr r11M(clk,rst,srcb3E,srcbM);
-    flopr r12M(clk,rst,cp0_data2E,cp0_dataM);
-    flopr r14M(clk,rst,cp0_countE,cp0_countM);
-    flopr r15M(clk,rst,cp0_compareE,cp0_compareM);
-    flopr r16M(clk,rst,cp0_statusE,cp0_causeM);
-    flopr r17M(clk,rst,cp0_causeE,cp0_causeM);
-    flopr r18M(clk,rst,cp0_epcE,cp0_epcM);
-    flopr r19M(clk,rst,cp0_configE,cp0_configM);
-    flopr r20M(clk,rst,cp0_badvaddrE,cp0_badvaddrM);
-    flopr #(1) r21M(clk,rst,cp0_timer_intE,cp0_timer_intM);
-    flopr r22M(clk,rst,pcE,pcM);
-    flopr #(1) r23M(clk,rst,isInDelayslotE,isInDelayslotM);
-    flopr #(6) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE},checkExceptionM[7:2]);
+	// flopr r1M(clk,rst,srcb2E,writedataM);
+	// flopr r2M(clk,rst,aluoutE,aluoutM);
+	// flopr #(5) r3M(clk,rst,writeregE,writeregM);
+    // flopr r5M(clk,rst,srca2E,srcaM);
+    // flopr r6M(clk,rst,HI2E,HIM);
+    // flopr r7M(clk,rst,LO2E,LOM);
+    // flopr r8M(clk,rst,mdResult_hiE,mdResult_hiM);
+    // flopr r9M(clk,rst,mdResult_loE,mdResult_loM);
+	// flopr #(4) r10M(clk,rst,memwriteE,memwriteM);
+    // flopr r11M(clk,rst,srcb3E,srcbM);
+    // flopr r12M(clk,rst,cp0_data2E,cp0_dataM);
+    // flopr r14M(clk,rst,cp0_countE,cp0_countM);
+    // flopr r15M(clk,rst,cp0_compareE,cp0_compareM);
+    // flopr r16M(clk,rst,cp0_statusE,cp0_causeM);
+    // flopr r17M(clk,rst,cp0_causeE,cp0_causeM);
+    // flopr r18M(clk,rst,cp0_epcE,cp0_epcM);
+    // flopr r19M(clk,rst,cp0_configE,cp0_configM);
+    // flopr r20M(clk,rst,cp0_badvaddrE,cp0_badvaddrM);
+    // flopr #(1) r21M(clk,rst,cp0_timer_intE,cp0_timer_intM);
+    // flopr r22M(clk,rst,pcE,pcM);
+    // flopr #(1) r23M(clk,rst,isInDelayslotE,isInDelayslotM);
+    // flopr #(6) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE},checkExceptionM[7:2]);
     // 更新hilo_reg前，确定HI、LO
     mux3 mux_HI2M(HIM,mdResult_hiM,srcaM,{regToHilo_hiM,mdToHiloM},HI2M);
     mux3 mux_LO2M(LOM,mdResult_loM,srcaM,{regToHilo_loM,mdToHiloM},LO2M);
@@ -304,23 +304,23 @@ module datapath(
 
 	// [mem -> writeBack]
 	// 暂存
-	// floprc r1W(clk,rst,flushW,aluoutM,aluoutW);
-	// floprc r2W(clk,rst,flushW,readdataM,readdataW);
-	// floprc #(5) r3W(clk,rst,flushW,writeregM,writeregW);
-    // floprc r4W(clk,rst,flushW,hilooutM,hilooutW);
-	// floprc #(4) r5W(clk,rst,flushW,memReadWidthM,memReadWidthW);
-	// floprc #(1) r6W(clk,rst,flushW,memLoadIsSignM,memLoadIsSignW);
-    // floprc r7W(clk,rst,flushW,cp0_dataM,cp0_dataW);
-	// floprc r8W(clk,rst,flushW,pcM,pcW);
+	floprc r1W(clk,rst,flushW,aluoutM,aluoutW);
+	floprc r2W(clk,rst,flushW,readdataM,readdataW);
+	floprc #(5) r3W(clk,rst,flushW,writeregM,writeregW);
+    floprc r4W(clk,rst,flushW,hilooutM,hilooutW);
+	floprc #(4) r5W(clk,rst,flushW,memReadWidthM,memReadWidthW);
+	floprc #(1) r6W(clk,rst,flushW,memLoadIsSignM,memLoadIsSignW);
+    floprc r7W(clk,rst,flushW,cp0_dataM,cp0_dataW);
+	floprc r8W(clk,rst,flushW,pcM,pcW);
 
-	flopr r1W(clk,rst,aluoutM,aluoutW);
-	flopr r2W(clk,rst,readdataM,readdataW);
-	flopr #(5) r3W(clk,rst,writeregM,writeregW);
-    flopr r4W(clk,rst,hilooutM,hilooutW);
-	flopr #(4) r5W(clk,rst,memReadWidthM,memReadWidthW);
-	flopr #(1) r6W(clk,rst,memLoadIsSignM,memLoadIsSignW);
-    flopr r7W(clk,rst,cp0_dataM,cp0_dataW);
-	flopr r8W(clk,rst,pcM,pcW);
+	// flopr r1W(clk,rst,aluoutM,aluoutW);
+	// flopr r2W(clk,rst,readdataM,readdataW);
+	// flopr #(5) r3W(clk,rst,writeregM,writeregW);
+    // flopr r4W(clk,rst,hilooutM,hilooutW);
+	// flopr #(4) r5W(clk,rst,memReadWidthM,memReadWidthW);
+	// flopr #(1) r6W(clk,rst,memLoadIsSignM,memLoadIsSignW);
+    // flopr r7W(clk,rst,cp0_dataM,cp0_dataW);
+	// flopr r8W(clk,rst,pcM,pcW);
 
 
 	// =============================

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -264,7 +264,7 @@ module datapath(
     floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
     floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
     floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
-    floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
+    floprc r16M(clk,rst,flushM,cp0_statusE,cp0_statusM);
     floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
     floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
     floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -141,6 +141,12 @@ module datapath(
 	flopenrc r2D(clk,rst,~stallD,flushD,instrF,instrD);
     flopenrc r4D(clk,rst,~stallD,flushD,pcF,pcD);
     flopenrc #(8) exceptionF2D(clk,rst,~stallD,flushD,{checkExceptionF[7],7'd0},checkExceptionD);
+
+	// flopenr r1D(clk,rst,~stallD,pc_plus4F,pc_plus4D);
+	// flopenr r2D(clk,rst,~stallD,instrF,instrD);
+    // flopenr r4D(clk,rst,~stallD,pcF,pcD);
+    // flopenr #(8) exceptionF2D(clk,rst,~stallD,{checkExceptionF[7],7'd0},checkExceptionD);
+
 	// 前推
 	// D阶段要读rs，那么看是否需要有会写入rs寄存器的指令在MEM阶段，如果有就前推
 	// 如果要前推，如果是从hilo寄存器写入rs，那么就推hilooutM
@@ -217,28 +223,52 @@ module datapath(
 
 	// [execute -> mem]
 	// 暂存
-	floprc r1M(clk,rst,flushM,srcb2E,writedataM);
-	floprc r2M(clk,rst,flushM,aluoutE,aluoutM);
-	floprc #(5) r3M(clk,rst,flushM,writeregE,writeregM);
-    floprc r5M(clk,rst,flushM,srca2E,srcaM);
-    floprc r6M(clk,rst,flushM,HI2E,HIM);
-    floprc r7M(clk,rst,flushM,LO2E,LOM);
-    floprc r8M(clk,rst,flushM,mdResult_hiE,mdResult_hiM);
-    floprc r9M(clk,rst,flushM,mdResult_loE,mdResult_loM);
-	floprc #(4) r10M(clk,rst,flushM,memwriteE,memwriteM);
-    floprc r11M(clk,rst,flushM,srcb3E,srcbM);
-    floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
-    floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
-    floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
-    floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
-    floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
-    floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
-    floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);
-    floprc r20M(clk,rst,flushM,cp0_badvaddrE,cp0_badvaddrM);
-    floprc #(1) r21M(clk,rst,flushM,cp0_timer_intE,cp0_timer_intM);
-    floprc r22M(clk,rst,flushM,pcE,pcM);
-    floprc #(1) r23M(clk,rst,flushM,isInDelayslotE,isInDelayslotM);
-    floprc #(8) exceptionE2M(clk,rst,flushM,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
+	// floprc r1M(clk,rst,flushM,srcb2E,writedataM);
+	// floprc r2M(clk,rst,flushM,aluoutE,aluoutM);
+	// floprc #(5) r3M(clk,rst,flushM,writeregE,writeregM);
+    // floprc r5M(clk,rst,flushM,srca2E,srcaM);
+    // floprc r6M(clk,rst,flushM,HI2E,HIM);
+    // floprc r7M(clk,rst,flushM,LO2E,LOM);
+    // floprc r8M(clk,rst,flushM,mdResult_hiE,mdResult_hiM);
+    // floprc r9M(clk,rst,flushM,mdResult_loE,mdResult_loM);
+	// floprc #(4) r10M(clk,rst,flushM,memwriteE,memwriteM);
+    // floprc r11M(clk,rst,flushM,srcb3E,srcbM);
+    // floprc r12M(clk,rst,flushM,cp0_data2E,cp0_dataM);
+    // floprc r14M(clk,rst,flushM,cp0_countE,cp0_countM);
+    // floprc r15M(clk,rst,flushM,cp0_compareE,cp0_compareM);
+    // floprc r16M(clk,rst,flushM,cp0_statusE,cp0_causeM);
+    // floprc r17M(clk,rst,flushM,cp0_causeE,cp0_causeM);
+    // floprc r18M(clk,rst,flushM,cp0_epcE,cp0_epcM);
+    // floprc r19M(clk,rst,flushM,cp0_configE,cp0_configM);
+    // floprc r20M(clk,rst,flushM,cp0_badvaddrE,cp0_badvaddrM);
+    // floprc #(1) r21M(clk,rst,flushM,cp0_timer_intE,cp0_timer_intM);
+    // floprc r22M(clk,rst,flushM,pcE,pcM);
+    // floprc #(1) r23M(clk,rst,flushM,isInDelayslotE,isInDelayslotM);
+    // floprc #(8) exceptionE2M(clk,rst,flushM,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
+
+
+	flopr r1M(clk,rst,srcb2E,writedataM);
+	flopr r2M(clk,rst,aluoutE,aluoutM);
+	flopr #(5) r3M(clk,rst,writeregE,writeregM);
+    flopr r5M(clk,rst,srca2E,srcaM);
+    flopr r6M(clk,rst,HI2E,HIM);
+    flopr r7M(clk,rst,LO2E,LOM);
+    flopr r8M(clk,rst,mdResult_hiE,mdResult_hiM);
+    flopr r9M(clk,rst,mdResult_loE,mdResult_loM);
+	flopr #(4) r10M(clk,rst,memwriteE,memwriteM);
+    flopr r11M(clk,rst,srcb3E,srcbM);
+    flopr r12M(clk,rst,cp0_data2E,cp0_dataM);
+    flopr r14M(clk,rst,cp0_countE,cp0_countM);
+    flopr r15M(clk,rst,cp0_compareE,cp0_compareM);
+    flopr r16M(clk,rst,cp0_statusE,cp0_causeM);
+    flopr r17M(clk,rst,cp0_causeE,cp0_causeM);
+    flopr r18M(clk,rst,cp0_epcE,cp0_epcM);
+    flopr r19M(clk,rst,cp0_configE,cp0_configM);
+    flopr r20M(clk,rst,cp0_badvaddrE,cp0_badvaddrM);
+    flopr #(1) r21M(clk,rst,cp0_timer_intE,cp0_timer_intM);
+    flopr r22M(clk,rst,pcE,pcM);
+    flopr #(1) r23M(clk,rst,isInDelayslotE,isInDelayslotM);
+    flopr #(8) exceptionE2M(clk,rst,{checkExceptionE[7:3],ex_ovE,2'b00},checkExceptionM);
     // 更新hilo_reg前，确定HI、LO
     mux3 mux_HI2M(HIM,mdResult_hiM,srcaM,{regToHilo_hiM,mdToHiloM},HI2M);
     mux3 mux_LO2M(LOM,mdResult_loM,srcaM,{regToHilo_loM,mdToHiloM},LO2M);
@@ -246,14 +276,23 @@ module datapath(
 
 	// [mem -> writeBack]
 	// 暂存
-	floprc r1W(clk,rst,flushW,aluoutM,aluoutW);
-	floprc r2W(clk,rst,flushW,readdataM,readdataW);
-	floprc #(5) r3W(clk,rst,flushW,writeregM,writeregW);
-    floprc r4W(clk,rst,flushW,hilooutM,hilooutW);
-	floprc #(4) r5W(clk,rst,flushW,memReadWidthM,memReadWidthW);
-	floprc #(1) r6W(clk,rst,flushW,memLoadIsSignM,memLoadIsSignW);
-    floprc r7W(clk,rst,flushW,cp0_dataM,cp0_dataW);
-	floprc r8W(clk,rst,flushW,pcM,pcW);
+	// floprc r1W(clk,rst,flushW,aluoutM,aluoutW);
+	// floprc r2W(clk,rst,flushW,readdataM,readdataW);
+	// floprc #(5) r3W(clk,rst,flushW,writeregM,writeregW);
+    // floprc r4W(clk,rst,flushW,hilooutM,hilooutW);
+	// floprc #(4) r5W(clk,rst,flushW,memReadWidthM,memReadWidthW);
+	// floprc #(1) r6W(clk,rst,flushW,memLoadIsSignM,memLoadIsSignW);
+    // floprc r7W(clk,rst,flushW,cp0_dataM,cp0_dataW);
+	// floprc r8W(clk,rst,flushW,pcM,pcW);
+
+	flopr r1W(clk,rst,aluoutM,aluoutW);
+	flopr r2W(clk,rst,readdataM,readdataW);
+	flopr #(5) r3W(clk,rst,writeregM,writeregW);
+    flopr r4W(clk,rst,hilooutM,hilooutW);
+	flopr #(4) r5W(clk,rst,memReadWidthM,memReadWidthW);
+	flopr #(1) r6W(clk,rst,memLoadIsSignM,memLoadIsSignW);
+    flopr r7W(clk,rst,cp0_dataM,cp0_dataW);
+	flopr r8W(clk,rst,pcM,pcW);
 
 
 	// =============================
@@ -455,7 +494,11 @@ module datapath(
     // [Memory] 决定 写入cp0的错误地址 是指令地址pcM 还是数据地址 aluoutM(注: 这里指令地址错误的优先级高于数据地址错误)
     mux2 mux_badAddr(aluoutM,pcM,checkExceptionM[7],badAddrM);
     // [Memory] 写cp0
-    cp0_reg cp0(clk,rst,isWritecp0M,writecp0AddrM,readcp0AddrE,srcbM,6'b000000,except_typeM,pcM,isInDelayslotM,badAddrM,cp0_countE,cp0_dataE,cp0_compareE,cp0_statusE,cp0_causeE,cp0_epcE,cp0_configE,cp0_pridE,cp0_badvaddrE,cp0_timer_intE);
+    cp0_reg cp0(clk,rst,
+	isWritecp0M,writecp0AddrM,readcp0AddrE,srcbM,
+	6'b000000,
+	except_typeM,pcM,isInDelayslotM,badAddrM,
+	cp0_countE,cp0_dataE,cp0_compareE,cp0_statusE,cp0_causeE,cp0_epcE,cp0_configE,cp0_pridE,cp0_badvaddrE,cp0_timer_intE);
 
     // [WriteBack] 判断写回寄存器堆的是：从ALU出来的结果（可能被BAL、JAL或JALR覆盖） or 从数据存储器读取的data or HI/LO寄存器的数据 or CP0寄存器的数据
 	// mux2 mux_regwriteData(aluoutW,readdataW,memtoregW,resultW);

--- a/inst52/myCPU/datapath/datapath.v
+++ b/inst52/myCPU/datapath/datapath.v
@@ -59,6 +59,7 @@ module datapath(
 	wire stallF;
 	wire [31:0] pc_plus4F;
 	wire [7:0] checkExceptionF;
+	wire flushF;
 
 	//decode stage
 	wire [31:0] pc_afterjumpD,pc_afterbranchD,pc_branch_offsetD;
@@ -72,6 +73,7 @@ module datapath(
     wire [31:0] HID,LOD;
     wire [31:0] pcD;
 	wire [7:0] checkExceptionD;
+	wire flushD;
 
 	//execute stage
 	wire [1:0] forwardaE,forwardbE;
@@ -115,12 +117,14 @@ module datapath(
     wire [31:0] badAddrM;
     wire [31:0] newPCM;
 	wire [7:0] checkExceptionM;
+	wire flushM;
 
 	//writeback stage
 	wire [31:0] aluoutW,readdataW,resultW,hilooutW;
 	wire [3:0] memReadWidthW;
 	wire memLoadIsSignW;
     wire [31:0] cp0_dataW;
+	wire flushW;
 
 
 
@@ -258,6 +262,7 @@ module datapath(
 	hazard h(
 		//fetch stage
 		.stallF(stallF),
+		.flushF(flushF),
 		//decode stage
 		.rsD(rsD),
 		.rtD(rtD),
@@ -267,6 +272,7 @@ module datapath(
 		.forwardbD(forwardbD),
 		.stallD(stallD),
 		.jrstall_READ(jrstall_READ),
+		.flushD(flushD),
 		//execute stage
 		.rsE(rsE),
 		.rtE(rtE),
@@ -298,9 +304,11 @@ module datapath(
         .except_typeM(except_typeM),
         .cp0_epcM(cp0_epcM),
         .newPCM(newPCM),
+		.flushM(flushM),
 		//write back stage
 		.writeregW(writeregW),
-		.regwriteW(regwriteW)
+		.regwriteW(regwriteW),
+		.flushW(flushW)
 	);
 
 
@@ -322,7 +330,7 @@ module datapath(
 	// [Fetch] PC 模块
 	flopenr_pc pcreg(clk,rst,~stallF,pc_next_addr,pcF);
     // [fetch] 标记取指令的地址是否对齐，不对齐产生例外
-    assign checkExceptionF[7] = (pcF[1:0]==2'b00) ? 1'b0 : 7'b1;
+    assign checkExceptionF = (pcF[1:0]==2'b00) ? 8'd0 : 8'b1000_0000;
 	// [Fetch] PC + 4
 	adder adder_plus4(pcF,32'd4,pc_plus4F);
 

--- a/inst52/myCPU/datapath/hazard.v
+++ b/inst52/myCPU/datapath/hazard.v
@@ -106,7 +106,7 @@ module hazard(
 
 	assign stallD = lwstallD | branchstallD | jrstall_READ | jrstall_WRITE | stall_divE;
 	assign stallF = lwstallD | branchstallD | jrstall_READ | jrstall_WRITE | stall_divE;
-	assign flushE = lwstallD | branchstallD | jrstall_READ;
+	assign flushE = lwstallD | branchstallD | jrstall_READ | (except_typeM!=32'd0);
     assign stallE = stall_divE;
 
     assign flushF = (except_typeM!=32'd0);

--- a/inst52/myCPU/datapath/hazard.v
+++ b/inst52/myCPU/datapath/hazard.v
@@ -3,6 +3,7 @@
 module hazard(
 	//fetch stage
 	output stallF,
+	output flushF,
 
 	//decode stage
 	input [4:0] rsD,rtD,
@@ -10,6 +11,7 @@ module hazard(
 	output forwardaD,forwardbD,
 	output stallD,
 	output jrstall_READ,
+	output flushD,
 
 	//execute stage
 	input [4:0] rsE,rtE,
@@ -36,10 +38,12 @@ module hazard(
     input [4:0] writecp0AddrM,
     input [31:0] except_typeM,cp0_epcM,
     output reg [31:0] newPCM,
+	output flushM,
 
 	//write back stage
 	input [4:0] writeregW,
-	input regwriteW
+	input regwriteW,
+	output flushW
 );
 
 	wire lwstallD,branchstallD,jrstall_WRITE;
@@ -104,6 +108,11 @@ module hazard(
 	assign stallF = lwstallD | branchstallD | jrstall_READ | jrstall_WRITE | stall_divE;
 	assign flushE = lwstallD | branchstallD | jrstall_READ;
     assign stallE = stall_divE;
+
+    assign flushF = (except_typeM!=32'd0);
+	assign flushD = (except_typeM!=32'd0);
+	assign flushM = (except_typeM!=32'd0);
+	assign flushW = (except_typeM!=32'd0);
 
     // 根据当前得到的例外类型跳转到例外处理程序入口（除了ERET外，都统一跳到0xBFC00380）
     always @(*) begin

--- a/inst52/myCPU/mips.v
+++ b/inst52/myCPU/mips.v
@@ -20,7 +20,7 @@ module mips(
 	wire regdstE,alusrcE,branchD,jalD,jrD,pcsrcD,memtoregE,memtoregM,memtoregW;
 	wire balE,jalE,jrE,regwriteE,regwriteM;
 	wire [4:0] alucontrolE;
-	wire flushE,validBranchConditionD;
+	wire flushE,flushM,flushW,validBranchConditionD;
     wire regToHilo_hiE,regToHilo_loE,mdToHiloE,mulOrdivE,mdIsSignE;
     wire regToHilo_hiM,regToHilo_loM,mdToHiloM;
     wire hilotoregE;
@@ -72,6 +72,7 @@ module mips(
         .jalrE(jalrE),
 		//[mem stage]
 		//				==input==
+		.flushM(flushM),
 		//				==output=
 		.memtoregM(memtoregM),		.memwriteE(memwriteE),
         .regToHilo_hiM(regToHilo_hiM),
@@ -88,6 +89,7 @@ module mips(
 		.data_sram_enM(data_sram_enM),
 		//[writeBack stage]
 		//				==input==
+		.flushW(flushW),
 		//				==output=
 		.memtoregW(memtoregW),		.regwriteW(regwriteW),
         .hilotoregW(hilotoregW),    .cp0ToRegW(cp0ToRegW)
@@ -145,13 +147,15 @@ module mips(
 		//				==output=
 		.aluoutM(aluoutM),			.writedataExtendedM(writedataM),
 		.memwrite_filterdM(memwriteEN),
+		.flushM(flushM),
 		//[writeBack stage]
 		//				==input==
 		.memtoregW(memtoregW), 		.regwriteW(regwriteW),
         .hilotoregW(hilotoregW),    .cp0ToRegW(cp0ToRegW),
 		//				==output=
 		.pcW(pcW),                  .writeregW(writeregW),
-        .result_filterdW(resultW)
+        .result_filterdW(resultW),
+		.flushW(flushW)
 	);
 
 endmodule

--- a/inst52/myCPU/utils/exception_type.v
+++ b/inst52/myCPU/utils/exception_type.v
@@ -10,10 +10,10 @@ module exception_type(
         if(rst) begin
             except_type <= 32'b0;
         end
-        else if((cp0_status[15:8] & cp0_cause[15:8] != 8'h00) && 
+        else if((cp0_status[15:8] & cp0_cause[15:8] != 8'h00) &&
                         (cp0_status[1] == 1'b0 && (cp0_status[0] == 1'b1))) begin
                             except_type <= 32'h00000001;//中断
-                        end 
+                        end
         else if(except[7] == 1'b1 || except[1] == 1'b1) begin
             except_type <= 32'h00000004;//ADEL
         end
@@ -35,6 +35,8 @@ module exception_type(
         else if(except[2] == 1'b1) begin
             except_type <= 32'h0000000c;//Ov
         end
+        else
+            except_type <= 32'd0;
     end
-    
+
 endmodule

--- a/inst52/myCPU/utils/flopenr_pc.v
+++ b/inst52/myCPU/utils/flopenr_pc.v
@@ -3,13 +3,16 @@
 
 
 module flopenr_pc #(parameter WIDTH = 32)(
-	input clk,rst,en,
+	input clk,rst,en,flushF,
 	input [WIDTH-1:0] d,
+	input [WIDTH-1:0] newpcM,
 	output reg [WIDTH-1:0] q
     );
 	always @(posedge clk) begin
 		if(rst)
 			q <= 32'hbfc00000;
+		else if(flushF)
+			q <= newpcM;
 		else if(en)
 			q <= d;
 	end


### PR DESCRIPTION
作出如下改动：
- 为datapath与controller每个阶段的暂存添加flush，除了flushE（原本存在的逻辑）之外，其余的flush都是由于异常而产生
- 加入新的数据前推：如果上一条（或上上一条指令）有从cp0读出数据并向寄存器写入，而当前指令需要读寄存器值，那么从MEM/WB推至当前的EXE阶段
- 修复对adel和ades例外的错误判断
- 如果存在ades例外，那么已经地址错误，禁止向内存写入数据
- 修复暂存cp0_status时的错误